### PR TITLE
[style & feat] 반응형 레이아웃 구현 & 비밀번호 재설정/인용 api 함수 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "react-hook-form": "^7.60.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
+        "uuid": "^11.1.0",
         "zod": "^4.0.5",
         "zustand": "^5.0.6"
       },
@@ -7280,6 +7281,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-hook-form": "^7.60.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
+    "uuid": "^11.1.0",
     "zod": "^4.0.5",
     "zustand": "^5.0.6"
   },

--- a/public/icons/menu.svg
+++ b/public/icons/menu.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="10" viewBox="0 0 14 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 1H13M1 5H13M1 9H13" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -22,6 +22,8 @@ api.interceptors.request.use(
       "/emails",
       "/checkId",
       "/findId",
+      "/findPwd",
+      "/resetPwd",
       "/oauth",
       "/oauth2",
       "/members/reissue",

--- a/src/apis/citation.api.ts
+++ b/src/apis/citation.api.ts
@@ -1,0 +1,167 @@
+import axios from "axios";
+import { api } from "./api";
+import {
+  EditCitationFileNameType,
+  FindCitationHistoryResponseData,
+  ReadDetailCitationInfoResponseData,
+  SendCitationType,
+  SendUrlResponseData,
+  SendUrlType,
+} from "@/types/citation.type";
+import { SuccessResponseData } from "@/types/common.type";
+import { Message } from "postcss";
+
+// 인용문을 생성할 정보가 담긴 URL 보내기
+export const sendUrl = async ({
+  url,
+  session,
+}: SendUrlType): Promise<SendUrlResponseData> => {
+  const path = "/cite/getUrlData";
+  try {
+    const response = await api.post<SendUrlResponseData>(path, {
+      url: url,
+      session: session,
+    });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error("[sendUrl] Axios 에러: ", error.response.data.message);
+        throw new Error(error.response.data.message);
+      } else console.error("[sendUrl] Axios 에러: ", error);
+    } else {
+      console.error("[sendUrl] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 인용문 보내기 (히스토리 저장을 위해)
+export const sendCitation = async ({
+  citeId,
+  citation,
+  style,
+}: SendCitationType): Promise<SuccessResponseData> => {
+  const path = "/cite/getCitation";
+  try {
+    const response = await api.post<SuccessResponseData>(path, {
+      citeId: citeId,
+      citation: citation,
+      style: style,
+    });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[sendCitation] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[sendCitation] Axios 에러: ", error);
+    } else {
+      console.error("[sendCitation] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 사용자별 인용문 히스토리 가져오기
+export const findCitationHistory = async (): Promise<
+  FindCitationHistoryResponseData[]
+> => {
+  const path = "/cite/myCitations";
+  try {
+    const response = await api.get<FindCitationHistoryResponseData[]>(path);
+    const data = response.data;
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[findCitationHistory] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[findCitationHistory] Axios 에러: ", error);
+    } else {
+      console.error("[findCitationHistory] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 인용문 상세 조회하기
+export const readDetailCitationInfo = async (
+  citeId: string
+): Promise<ReadDetailCitationInfoResponseData> => {
+  const path = `/cite/citeDetail/${citeId}`;
+  try {
+    const response = await api.get<ReadDetailCitationInfoResponseData>(path);
+    const data = response.data;
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[readDetailCitationInfo] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[readDetailCitationInfo] Axios 에러: ", error);
+    } else {
+      console.error("[readDetailCitationInfo] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 파일 이름 변경하기
+export const editCitationFileName = async ({
+  citeId,
+  title,
+}: EditCitationFileNameType): Promise<Message> => {
+  const path = "/cite/renameCiteFile";
+  try {
+    const response = await api.patch<Message>(path, {
+      citeId: citeId,
+      newTitle: title,
+    });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[editCitationFileName] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[editCitationFileName] Axios 에러: ", error);
+    } else {
+      console.error("[editCitationFileName] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 파일 삭제하기
+export const deleteCitationFile = async (): Promise<Message> => {
+  const path = "/cite/deleteCiteFile";
+  try {
+    const response = await api.delete<Message>(path);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[deleteCitationFile] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[deleteCitationFile] Axios 에러: ", error);
+    } else {
+      console.error("[deleteCitationFile] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};

--- a/src/apis/findId.api.ts
+++ b/src/apis/findId.api.ts
@@ -1,15 +1,16 @@
 import axios from "axios";
 import { api } from "./api";
+import { SuccessResponseData } from "@/types/common.type";
 
 // 아이디 찾기(이메일로 아이디 전송)
-export const findId = async (email: string) => {
+export const findId = async (email: string): Promise<SuccessResponseData> => {
   const path = "/members/findId";
 
   try {
-    const response = await api.post(path, {
+    const response = await api.post<SuccessResponseData>(path, {
       email: email,
     });
-    return response;
+    return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
       if (error.response?.data.code) {

--- a/src/apis/findpw.api.ts
+++ b/src/apis/findpw.api.ts
@@ -1,0 +1,49 @@
+import axios from "axios";
+import { api } from "./api";
+import { ResetPasswordType } from "@/types/auth.type";
+
+// 비밀번호 재설정 링크 전송
+export const sendResetPwLink = async (email: string) => {
+  const path = "/members/findPwd";
+
+  try {
+    const response = await api.post(path, { email: email });
+    return response;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[sendResetPwLink] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[sendResetPwLink] Axios 에러: ", error);
+    } else {
+      console.error("[sendResetPwLink] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 비밀번호 재설정
+export const resetPassword = async ({ token, newPwd }: ResetPasswordType) => {
+  const path = "/members/resetPwd";
+
+  try {
+    const response = await api.post(path, { token: token, newPwd: newPwd });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[resetPassword] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[resetPassword] Axios 에러: ", error);
+    } else {
+      console.error("[resetPassword] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};

--- a/src/apis/login.api.ts
+++ b/src/apis/login.api.ts
@@ -1,17 +1,20 @@
-import { LoginType } from "@/types/auth.type";
+import { LoginResponseData, LoginType } from "@/types/auth.type";
 import { api } from "./api";
 import axios from "axios";
 
 // 자체 로그인
-export const selfLogin = async ({ id, pw }: LoginType) => {
+export const selfLogin = async ({
+  id,
+  pw,
+}: LoginType): Promise<LoginResponseData> => {
   const path = "/members/login";
 
   try {
-    const response = await api.post(path, {
+    const response = await api.post<LoginResponseData>(path, {
       id: id,
       pwd: pw,
     });
-    return response;
+    return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
       if (error.response?.data.code) {
@@ -25,22 +28,14 @@ export const selfLogin = async ({ id, pw }: LoginType) => {
   }
 };
 
-interface OAuthTokenResponseData {
-  accessToken: string;
-  memberId: number;
-  id: string;
-  email: string;
-  role: string;
-}
-
 // 소셜 로그인 토큰 발급
 export const requestOAuthToken = async (
   code: string
-): Promise<OAuthTokenResponseData> => {
+): Promise<LoginResponseData> => {
   const path = "/oauth/token";
 
   try {
-    const response = await api.post<OAuthTokenResponseData>(path, {
+    const response = await api.post<LoginResponseData>(path, {
       code: code,
     });
     return response.data;

--- a/src/apis/logout.api.ts
+++ b/src/apis/logout.api.ts
@@ -1,13 +1,14 @@
 import axios from "axios";
 import { api } from "./api";
+import { SuccessResponseData } from "@/types/common.type";
 
 // 로그아웃
-export const logout = async () => {
+export const logout = async (): Promise<SuccessResponseData> => {
   const path = "/members/logout";
 
   try {
-    const response = await api.post(path);
-    return response;
+    const response = await api.post<SuccessResponseData>(path);
+    return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
       if (error.response?.data.code) {

--- a/src/apis/signup.api.ts
+++ b/src/apis/signup.api.ts
@@ -1,14 +1,24 @@
 import axios from "axios";
 import { api } from "./api";
-import { CheckEmailNumberType, SignupType } from "@/types/auth.type";
+import {
+  CheckEmailNumberType,
+  CheckIdResponseData,
+  SignupResponseData,
+  SignupType,
+} from "@/types/auth.type";
+import { SuccessResponseData } from "@/types/common.type";
 
 // 이메일로 인증번호 전송
-export const sendEmail = async (email: string) => {
+export const sendEmail = async (
+  email: string
+): Promise<SuccessResponseData> => {
   const path = "/members/emails/mailSend";
 
   try {
-    const response = await api.post(path, { email: email });
-    return response;
+    const response = await api.post<SuccessResponseData>(path, {
+      email: email,
+    });
+    return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
       if (error.response?.data.code) {
@@ -26,15 +36,15 @@ export const sendEmail = async (email: string) => {
 export const checkEmailNumber = async ({
   email,
   emailNum,
-}: CheckEmailNumberType) => {
+}: CheckEmailNumberType): Promise<SuccessResponseData> => {
   const path = "/members/emails/mailAuthCheck";
 
   try {
-    const response = await api.post(path, {
+    const response = await api.post<SuccessResponseData>(path, {
       email: email,
       authNum: emailNum,
     });
-    return response;
+    return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
       if (error.response?.data.code) {
@@ -52,12 +62,14 @@ export const checkEmailNumber = async ({
 };
 
 // 아이디 중복 확인
-export const checkIdDuplicated = async (id: string) => {
+export const checkIdDuplicated = async (
+  id: string
+): Promise<CheckIdResponseData> => {
   const path = "/members/checkId";
 
   try {
-    const response = await api.post(path, { id: id });
-    return response;
+    const response = await api.post<CheckIdResponseData>(path, { id: id });
+    return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
       if (error.response?.data.code) {
@@ -75,16 +87,20 @@ export const checkIdDuplicated = async (id: string) => {
 };
 
 // 회원가입
-export const signup = async ({ id, pw, email }: SignupType) => {
+export const signup = async ({
+  id,
+  pw,
+  email,
+}: SignupType): Promise<SignupResponseData> => {
   const path = "/members/signUp";
 
   try {
-    const response = await api.post(path, {
+    const response = await api.post<SignupResponseData>(path, {
       id: id,
       pwd: pw,
       email: email,
     });
-    return response;
+    return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
       if (error.response?.data.code) {

--- a/src/app/(auth)/find-id/page.tsx
+++ b/src/app/(auth)/find-id/page.tsx
@@ -18,8 +18,8 @@ export default function FindIdPage() {
   } = useMutation({
     mutationKey: ["findId"],
     mutationFn: findId,
-    onSuccess: (response) => {
-      console.log("✅ 아이디 전송 성공", response);
+    onSuccess: (data) => {
+      console.log("✅ 아이디 전송 성공", data);
       alert("입력하신 이메일로 아이디가 전송되었습니다.");
     },
     onError: (err) => {

--- a/src/app/(auth)/login/oauth/OAuthRedirectPageContent.tsx
+++ b/src/app/(auth)/login/oauth/OAuthRedirectPageContent.tsx
@@ -13,9 +13,9 @@ const OAuthRedirectPageContent = () => {
 
   const { mutate, isPending, isError, error } = useMutation({
     mutationFn: requestOAuthToken,
-    onSuccess: (response) => {
-      login(response.accessToken, response.id);
-      alert(`${response.id}님, 안녕하세요!`);
+    onSuccess: (data) => {
+      login(data.accessToken, data.id);
+      alert(`${data.id}님, 안녕하세요!`);
       router.push("/");
     },
     onError: (err) => {

--- a/src/app/(auth)/reset-pw/page.tsx
+++ b/src/app/(auth)/reset-pw/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { sendResetPwLink } from "@/apis/findpw.api";
 import InputWithLabel from "@/components/ui/input/InputWithLabel";
 import useSignupForm from "@/hooks/useSignupForm";
+import { useMutation } from "@tanstack/react-query";
 import clsx from "clsx";
 import Link from "next/link";
 
@@ -9,8 +11,26 @@ export default function ResetPwPage() {
   const { email, setEmail, isEmailInvalid, emailErrorMessage } =
     useSignupForm();
 
+  const {
+    mutate: sendResetPwLinkMutate,
+    isPending: isSendingResetPwLink,
+    isSuccess: isLinkSendSuccessful,
+  } = useMutation({
+    mutationKey: ["sendResetPwLink"],
+    mutationFn: sendResetPwLink,
+    onSuccess: (data) => {
+      console.log("✅ 비밀번호 재설정 링크 전송 성공", data);
+      alert("입력하신 이메일로 비밀번호 재설정 링크가 전송되었습니다.");
+    },
+    onError: (err) => {
+      console.error("❌ 비밀번호 재설정 링크 전송 실패: ", err.message);
+      alert(err.message);
+    },
+  });
+
   const handleSendResetPwLink = (e: React.FormEvent) => {
     e.preventDefault();
+    sendResetPwLinkMutate(email);
   };
 
   return (
@@ -49,13 +69,21 @@ export default function ResetPwPage() {
             type="submit"
             className={clsx(
               "text-[14px] w-[255px]  text-white py-[10px] rounded-[4px]",
-              isEmailInvalid || !email
+              isSendingResetPwLink ||
+                isEmailInvalid ||
+                !email ||
+                isLinkSendSuccessful
                 ? "bg-main/40"
                 : "bg-main/70 hover:bg-main"
             )}
-            disabled={isEmailInvalid || !email}
+            disabled={
+              isSendingResetPwLink ||
+              isEmailInvalid ||
+              !email ||
+              isLinkSendSuccessful
+            }
           >
-            비밀번호 재설정 링크 전송
+            {isSendingResetPwLink ? "전송 중..." : "비밀번호 재설정 링크 전송"}
           </button>
         </div>
         <Link

--- a/src/app/(main-service)/layout.tsx
+++ b/src/app/(main-service)/layout.tsx
@@ -10,9 +10,11 @@ export default function NavBarLayout({
 }>) {
   return (
     <div className="flex h-screen">
-      <NavBar />
+      <div className="hidden lg:block">
+        <NavBar />
+      </div>
       <SidebarProvider defaultOpen={false}>
-        <main className="flex-1 flex">{children}</main>
+        <main className="w-full flex">{children}</main>
         <SideBar />
         <SearchDialog />
       </SidebarProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import "./globals.css";
 import QueryProvider from "./_provider";
 import Header from "@/components/layout/Header";
 import Script from "next/script";
+import MobileHeader from "@/components/layout/MobileHeader";
+import MobileNavBar from "@/components/layout/MobileNavBar";
 
 export const metadata: Metadata = {
   title: "Phraiz",
@@ -46,8 +48,14 @@ export default function RootLayout({
           }}
         />
         <QueryProvider>
-          <Header />
-          <main className="min-h-screen">{children}</main>
+          <div className="block relative lg:hidden">
+            <MobileHeader />
+            <MobileNavBar />
+          </div>
+          <div className="hidden lg:block">
+            <Header />
+          </div>
+          <main className="min-h-screen w-full">{children}</main>
         </QueryProvider>
       </body>
     </html>

--- a/src/components/box/ChangeExistedCitationBox.tsx
+++ b/src/components/box/ChangeExistedCitationBox.tsx
@@ -40,27 +40,32 @@ const ChangeExistedCitationBox = () => {
   };
 
   return (
-    <div className="w-1/2 border-r p-[16px] flex flex-col gap-[20px]">
-      <div className="flex flex-col gap-[5px]">
-        <h1 className="text-[18px]">변환할 인용문을 입력하세요</h1>
+    <div className="p-[16px] flex flex-col gap-[10px] md:gap-[15px] w-full">
+      <div className="flex flex-col gap-[2px] md:gap-[5px]">
+        <h1 className="text-[14px] sm:text-[16px] md:text-[18px]">
+          변환할 인용문을 입력하세요
+        </h1>
         <Input
           type="text"
           value={citationValue}
           onChange={(e) => setCitationValue(e.target.value)}
+          className="text-[12px] sm:text-[14px] md:text-[16px] h-[26px] sm:h-[30px] md:h-[36px] px-[6px] sm:px-[8px] md:px-[12px]"
         />
       </div>
-      <div className="flex flex-col gap-[5px]">
-        <h1 className="text-[18px]">변환할 인용 형식을 선택하세요</h1>
+      <div className="flex flex-col gap-[2px] md:gap-[5px]">
+        <h1 className="text-[14px] sm:text-[16px] md:text-[18px]">
+          변환할 인용 형식을 선택하세요
+        </h1>
         <SelectScrollable
           selectedForm={selectedForm}
           setSelectedForm={setSelectedForm}
         />
       </div>
-      <div className="mt-[20px]">
+      <div className="mt-[5px]">
         <button
           onClick={handleChangeCitation}
           disabled
-          className="bg-main/40 text-white py-[10px] px-[16px] rounded-[6px]"
+          className="bg-main/40 text-white py-[6px] px-[10px] md:py-[10px] md:px-[16px] rounded-[6px] text-[10px] sm:text-[13px] md:text-[16px]"
         >
           인용문 변환하기
         </button>

--- a/src/components/box/ContentBox.tsx
+++ b/src/components/box/ContentBox.tsx
@@ -2,15 +2,12 @@
 
 import React, { useEffect, useState } from "react";
 import clsx from "clsx";
-import { useSidebar } from "../ui/sidebar/sidebar";
 import CreateNewCitationBox from "./CreateNewCitationBox";
 import ChangeExistedCitationBox from "./ChangeExistedCitationBox";
 
 const HEADER_H = 72; // px
 
 const ContentBox = () => {
-  const { open } = useSidebar();
-
   const [isCreatingNewCitation, setIsCreatingNewCitation] =
     useState<boolean>(true);
 
@@ -41,15 +38,20 @@ const ContentBox = () => {
   }, []);
 
   return (
-    <section className="flex flex-col h-full p-4 space-y-4">
+    <section className="flex flex-col w-full h-full p-4 gap-[6px] md:gap-[10px]">
       <header className="flex justify-between items-center px-[3px]">
-        <h1 className="text-2xl font-bold text-gray-800">인용 생성</h1>
+        <h1 className="text-[18px] xs:text-[20px] md:text-2xl font-bold text-gray-800">
+          인용 생성
+        </h1>
       </header>
-      <div className="flex gap-[15px]">
+      <div className="flex gap-[10px] md:gap-[15px] text-[12px] md:text-[16px]">
         <button
           onClick={() => setIsCreatingNewCitation(true)}
           className={clsx(
-            "rounded-full p-[10px] px-[20px] text-white bg-gradient-to-b from-[#4613ff] to-[#a37eff] [filter:drop-shadow(0px_0px_2px_rgba(70,19,255,1))] hover:shadow-[0_0_0_1px_#ab8ff2] hover:[filter:drop-shadow(0px_0px_4px_rgba(70,19,255,1))] transition-shadow duration-300"
+            "rounded-full py-[6px] px-[12px] md:py-[10px] md:px-[20px] text-white transition-all duration-300",
+            isCreatingNewCitation
+              ? "bg-gradient-to-b from-[#4613ff] to-[#a37eff] [filter:drop-shadow(0px_0px_2px_rgba(70,19,255,1))] hover:shadow-[0_0_0_1px_#ab8ff2]"
+              : "bg-[#a37eff]/40 hover:shadow-[0_0_0_1px_rgba(163,126,255,0.5)]"
           )}
         >
           새 인용문 생성
@@ -57,7 +59,10 @@ const ContentBox = () => {
         <button
           onClick={() => setIsCreatingNewCitation(false)}
           className={clsx(
-            "rounded-full p-[10px] px-[20px] text-white bg-gradient-to-b from-[#4613ff] to-[#a37eff] [filter:drop-shadow(0px_0px_2px_rgba(70,19,255,1))] hover:shadow-[0_0_0_1px_#ab8ff2] hover:[filter:drop-shadow(0px_0px_4px_rgba(70,19,255,1))] transition-shadow duration-300"
+            "rounded-full py-[6px] px-[12px] md:py-[10px] md:px-[20px] text-white  transition-all duration-300",
+            isCreatingNewCitation
+              ? "bg-[#a37eff]/40 hover:shadow-[0_0_0_1px_rgba(163,126,255,0.5)]"
+              : "bg-gradient-to-b from-[#4613ff] to-[#a37eff] [filter:drop-shadow(0px_0px_2px_rgba(70,19,255,1))]"
           )}
         >
           기존 인용문 변환
@@ -65,8 +70,8 @@ const ContentBox = () => {
       </div>
       <div
         className={clsx(
-          "flex flex-1 rounded-md shadow-md overflow-y-auto border my-[10px]",
-          open ? "w-[calc(100vw_-_437px)]" : "w-[calc(100vw_-_223px)]"
+          "flex flex-col rounded-md shadow-md overflow-y-auto border my-[10px] h-full w-full"
+          // open ? "lg:w-[calc(100vw_-_437px)]" : "lg:w-[calc(100vw_-_223px)]",
         )}
       >
         {/* 왼쪽 영역 */}
@@ -77,7 +82,7 @@ const ContentBox = () => {
         )}
 
         {/* 오른쪽 영역 */}
-        <div className="w-1/2 p-[16px]">{/* 여기에 결과 등 출력 */}</div>
+        <div className="w-full p-[16px] border-t">결과가 출력됩니다.</div>
       </div>
     </section>
   );

--- a/src/components/box/CreateNewCitationBox.tsx
+++ b/src/components/box/CreateNewCitationBox.tsx
@@ -5,6 +5,10 @@ import { Input } from "../ui/input/input";
 import SelectScrollable from "../ui/select/SelectScrollable";
 import { useAuthStore } from "@/stores/auth.store";
 import { useRouter } from "next/navigation";
+import { useMutation } from "@tanstack/react-query";
+import { sendUrl } from "@/apis/citation.api";
+import { v7 as uuidv7 } from "uuid";
+import clsx from "clsx";
 
 const CreateNewCitationBox = () => {
   const [urlValue, setUrlValue] = useState<string>("");
@@ -15,20 +19,21 @@ const CreateNewCitationBox = () => {
   const isLogin = useAuthStore((s) => s.isLogin);
   const router = useRouter();
 
+  console.log("urlValue:", urlValue);
+  console.log("selectedForm:", selectedForm);
+
   // 인용문 생성 뮤테이션
-  // const {
-  //   mutate
-  // } = useMutation({
-  //   mutationKey: ["api 함수명", urlValue, selectedForm],
-  //   mutationFn: api 함수,
-  //   onSuccess: (response) => {
-  //     console.log("✅ 인용문 생성 성공", response);
-  //   },
-  //   onError: (err) => {
-  //     console.error("❌ 인용문 생성 실패: ", err.message);
-  //     alert(err.message);
-  //   },
-  // });
+  const { mutate: sendUrlMutate, isPending: isSendingUrl } = useMutation({
+    mutationKey: ["sendUrl", urlValue, selectedForm],
+    mutationFn: sendUrl,
+    onSuccess: (data) => {
+      console.log("✅ 인용문 생성 성공", data);
+    },
+    onError: (err) => {
+      console.error("❌ 인용문 생성 실패: ", err.message);
+      alert(err.message);
+    },
+  });
 
   // 인용문 생성 핸들러
   const handleCreateCitation = () => {
@@ -37,32 +42,54 @@ const CreateNewCitationBox = () => {
       router.push("/login");
       return;
     }
+
+    if (!urlValue || !urlValue.trim()) {
+      alert("URL을 입력해주세요.");
+      return;
+    }
+    if (!selectedForm) {
+      alert("인용 형식을 선택해주세요.");
+      return;
+    }
+
+    const sessionId = uuidv7();
+    sendUrlMutate({ url: urlValue, session: sessionId });
   };
 
   return (
-    <div className="w-1/2 border-r p-[16px] flex flex-col gap-[20px]">
-      <div className="flex flex-col gap-[5px]">
-        <h1 className="text-[18px]">URL을 입력하세요</h1>
+    <div className="p-[16px] flex flex-col gap-[10px] md:gap-[15px] w-full">
+      <div className="flex flex-col gap-[2px] md:gap-[5px]">
+        <h1 className="text-[14px] sm:text-[16px] md:text-[18px]">
+          URL을 입력하세요
+        </h1>
         <Input
           type="text"
           value={urlValue}
           onChange={(e) => setUrlValue(e.target.value)}
+          className="text-[12px] sm:text-[14px] md:text-[16px] h-[26px] sm:h-[30px] md:h-[36px] px-[6px] sm:px-[8px] md:px-[12px]"
         />
       </div>
-      <div className="flex flex-col gap-[5px]">
-        <h1 className="text-[18px]">인용 형식을 선택하세요</h1>
+      <div className="flex flex-col gap-[2px] md:gap-[5px]">
+        <h1 className="text-[14px] sm:text-[16px] md:text-[18px]">
+          인용 형식을 선택하세요
+        </h1>
         <SelectScrollable
           selectedForm={selectedForm}
           setSelectedForm={setSelectedForm}
         />
       </div>
-      <div className="mt-[20px]">
+      <div className="mt-[5px]">
         <button
           onClick={handleCreateCitation}
-          disabled
-          className="bg-main/40 text-white py-[10px] px-[16px] rounded-[6px]"
+          disabled={!urlValue || !selectedForm || isSendingUrl}
+          className={clsx(
+            "text-white py-[6px] px-[10px] md:py-[10px] md:px-[16px] rounded-[6px] text-[10px] sm:text-[13px] md:text-[16px]",
+            !urlValue || !selectedForm || isSendingUrl
+              ? "bg-main/40"
+              : "bg-main/70 hover:bg-main"
+          )}
         >
-          인용 생성하기
+          {isSendingUrl ? "인용 생성 중..." : "인용 생성하기"}
         </button>
       </div>
     </div>

--- a/src/components/landing/FeatureCard.tsx
+++ b/src/components/landing/FeatureCard.tsx
@@ -49,7 +49,7 @@ const FeatureCard = ({ feature, href, ctaText }: FeatureCardProps) => {
       {/* 기본 내용 (hover 시 희미해짐) */}
       <div
         data-fade
-        className="z-10 flex flex-col items-center justify-center text-center gap-[10px] px-6 w-full h-full
+        className="z-10 flex flex-col items-center justify-center text-center gap-[10px] px-[16px] sm:px-[24px] w-full h-full
         "
       >
         <h3
@@ -61,7 +61,7 @@ const FeatureCard = ({ feature, href, ctaText }: FeatureCardProps) => {
         ></h3>
         <p
           data-fade
-          className="text-[12px] sm:text-[13px] md:text-[15px] lg:text-[16px] group-hover:opacity-50"
+          className="text-[13px] md:text-[15px] lg:text-[16px] group-hover:opacity-50"
           dangerouslySetInnerHTML={{
             __html: `${feature.description}`,
           }}

--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const Footer = () => {
   return (
-    <footer className="flex flex-col justify-end text-[12px] bg-main/20 h-[300px] items-center pb-[30px]">
+    <footer className="flex flex-col justify-end text-[9px] md:text-[12px] bg-main/20 h-[300px] items-center pb-[30px]">
       <p>2025 IT Project | 김현진 김희서 안선아 조은빈 | Soongsil University</p>
       <p>Copyright © 2025 Codiva. All rights reserved.</p>
     </footer>

--- a/src/components/landing/LandingSection.tsx
+++ b/src/components/landing/LandingSection.tsx
@@ -49,10 +49,17 @@ const LandingSection = ({ data, idx }: LandingSectionProps) => {
     >
       <h1
         data-fade
-        className="text-[30px] sm:text-[36px] md:text-[46px] lg:text-[50px]  font-nanum-extrabold [filter:drop-shadow(4px_4px_10px_rgba(0,0,0,0.2))] bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent mb-[-10px]"
+        className="hidden md:block text-[22px] xs:text-[30px] sm:text-[35px] md:text-[40px] lg:text-[50px]  font-nanum-extrabold [filter:drop-shadow(4px_4px_10px_rgba(0,0,0,0.2))] bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent mb-[-10px]"
       >
         {data.title}
       </h1>
+      <h1
+        data-fade
+        className="block md:hidden text-[22px] xs:text-[30px] sm:text-[35px] md:text-[40px] lg:text-[50px]  font-nanum-extrabold [filter:drop-shadow(4px_4px_10px_rgba(0,0,0,0.2))] bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent mb-[-10px] text-center"
+        dangerouslySetInnerHTML={{
+          __html: `${data.preTitle ? data.preTitle : data.title}`,
+        }}
+      ></h1>
 
       <div className="relative w-[240px] h-[160px] sm:w-[270px] sm:h-[180px] md:w-[300px] md:h-[200px] lg:w-[360px] lg:h-[240px]">
         <Image

--- a/src/components/landing/Main.tsx
+++ b/src/components/landing/Main.tsx
@@ -88,17 +88,20 @@ const Main = () => {
       ref={containerRef}
       className="relative h-screen overflow-hidden flex flex-col items-center justify-center gap-[50px] bg-gradient-to-b from-main to-main/20"
     >
-      <div className="font-nanum-extrabold text-white text-[40px] sm:text-[46px] md:text-[56px] lg:text-[72px] mt-[-50px] text-glow z-[9999]">
-        <h1 ref={h1Ref} className="ml-[-80px]">
+      <div className="font-nanum-extrabold text-white text-[30px] xs:text-[36px] sm:text-[46px] md:text-[56px] lg:text-[72px] mt-[-50px] text-glow z-[9000]">
+        <h1 ref={h1Ref} className="ml-[0px] xs:ml-[-80px]">
           누구나 전문가처럼 쓰는 시대,
         </h1>
-        <h1 ref={h2Ref} className="text-right mr-[-80px] mt-[-5px]">
+        <h1
+          ref={h2Ref}
+          className="text-right mr-[0px] xs:mr-[-80px] mt-[0px] xs:mt-[-5px]"
+        >
           Phraiz로.
         </h1>
       </div>
       <Link
         href="/ai-paraphrase"
-        className="relative overflow-hidden group rounded-full bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] text-white py-[14px] px-[40px] hover:font-nanum-bold [filter:drop-shadow(0px_0px_8px_rgba(119,82,254,1))]"
+        className="relative overflow-hidden group rounded-full bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] text-white py-[12px] px-[30px] sm:py-[14px] sm:px-[40px] hover:font-nanum-bold [filter:drop-shadow(0px_0px_8px_rgba(119,82,254,1))] text-[14px] sm:text-[16px]"
       >
         {/* ─── 텍스트 래퍼 ─── */}
         <span className="relative block h-full overflow-hidden">
@@ -133,37 +136,37 @@ const Main = () => {
         makeIcon(
           Icon1,
           0,
-          "top-[20%]  left-[6%] w-[100px] md:w-[110px] lg:w-[130px]"
+          "top-[24%] md:top-[22%] lg:top-[20%] left-[6%] w-[60px] xs:w-[70px] sm:w-[80px] md:w-[100px] lg:w-[130px]"
         ),
         makeIcon(
           Icon2,
           1,
-          "bottom-[14%] left-[10%] w-[100px] md:w-[110px] lg:w-[130px]"
+          "bottom-[20%] lg:bottom-[14%] left-[10%] w-[60px] xs:w-[70px] sm:w-[80px] md:w-[100px] lg:w-[130px]"
         ),
         makeIcon(
           Icon3,
           2,
-          "top-[30%] right-[10%] w-[120px] md:w-[130px] lg:w-[150px]"
+          "top-[27%] md:top-[25%] lg:top-[30%] right-[10%] w-[80px] xs:w-[90px] sm:w-[100px] md:w-[120px] lg:w-[150px]"
         ),
         makeIcon(
           Icon4,
           3,
-          "top-[45%] left-[28%] w-[100px] md:w-[110px] lg:w-[130px]"
+          "top-[43%] lg:top-[45%] left-[5%] md:left-[20%] lg:left-[28%] w-[60px] xs:w-[70px] sm:w-[80px] md:w-[100px] lg:w-[130px]"
         ),
         makeIcon(
           Icon5,
           4,
-          "top-[5%] left-[32%] w-[100px] md:w-[110px] lg:w-[130px]"
+          "top-[15%] sm:top-[10%] lg:top-[5%] left-[32%] w-[60px] xs:w-[70px] sm:w-[80px] md:w-[100px] lg:w-[130px]"
         ),
         makeIcon(
           Icon6,
           5,
-          "top-[0%] right-[30%] w-[120px] md:w-[130px] lg:w-[150px]"
+          "top-[3%] lg:top-[0%] right-[30%] w-[80px] xs:w-[90px] sm:w-[100px] md:w-[120px] lg:w-[150px]"
         ),
         makeIcon(
           Icon7,
           6,
-          "top-[60%] right-[20%] w-[100px] md:w-[110px] lg:w-[130px]"
+          "top-[60%] right-[20%] w-[60px] xs:w-[70px] sm:w-[80px] md:w-[100px] lg:w-[130px]"
         ),
       ]}
     </section>

--- a/src/components/landing/PricingPlan.tsx
+++ b/src/components/landing/PricingPlan.tsx
@@ -15,7 +15,7 @@ const PricingPlan = () => {
   return (
     <section
       className={clsx(
-        "h-[calc(100vh+30px)] w-full flex flex-col gap-[20px] justify-center items-center",
+        "h-[1500px] xs:h-[1600px] sm:h-[1000px] lg:h-[calc(100vh+30px)] w-full flex flex-col gap-[20px] justify-center items-center",
         pathname === "/"
           ? "bg-gradient-to-b from-main/60 to-main/20"
           : "pb-[120px] bg-gradient-to-b from-main to-main/20"
@@ -24,25 +24,45 @@ const PricingPlan = () => {
       <h1 className="text-[26px] sm:text-[28px] md:text-[30px] lg:text-[34px] font-nanum-extrabold [filter:drop-shadow(4px_4px_4px_rgba(0,0,0,0.3))]">
         {pathname === "/" ? "Pricing Plan" : "플랜 업그레이드"}
       </h1>
-      <div className="flex flex-wrap justify-center gap-[10px] sm:gap-[12px] md:gap-[16px] lg:gap-[20px]">
+      <div className="flex flex-wrap justify-center gap-[20px]">
         {PRICING_PLAN.map((plan) => (
           <div
             key={plan.name}
-            className="flex flex-col justify-between rounded-[16px] bg-white h-[270px] w-[240px] sm:h-[300px] sm:w-[270px] md:h-[350px] md:w-[300px] p-[20px] [filter:drop-shadow(0px_0px_10px_rgba(0,0,0,0.3))] hover:cursor-pointer hover:[filter:drop-shadow(0px_0px_14px_rgba(0,0,0,0.6))] transition-transform duration-300 ease-in-out transform hover:scale-105"
+            className="flex flex-col gap-[10px] md:gap-[20px] rounded-[16px] bg-white h-[340px] w-[240px] sm:h-[350px] sm:w-[270px] md:h-[420px] md:w-[300px] p-[20px] [filter:drop-shadow(0px_0px_10px_rgba(0,0,0,0.3))] hover:cursor-pointer hover:[filter:drop-shadow(0px_0px_14px_rgba(0,0,0,0.6))] transition-transform duration-300 ease-in-out transform hover:scale-105"
           >
             <div>
               <h1 className="font-nanum-extrabold text-[22px] sm:text-[24px] md:text-[26px] lg:text-[30px]">
                 {plan.name}
               </h1>
-              <h1 className="text-[14px] sm:text-[16px] md:text-[18px] lg:text-[20px]">
-                <span className="font-nanum-bold">{plan.price}</span> 원/월
+              {plan.name === "Free" ? (
+                <h1 className="text-[14px] sm:text-[16px] md:text-[18px] lg:text-[20px]">
+                  <span className="font-nanum-bold">0</span>원
+                </h1>
+              ) : (
+                <div className="flex gap-[10px]">
+                  <p className="text-[14px] sm:text-[16px] md:text-[18px] lg:text-[20px]">
+                    월
+                    <span className="font-nanum-bold"> {plan.monthPrice}</span>
+                    원
+                  </p>
+                  <div className="border-[0.8px] md:border w-0 h-[13px] md:h-[17px] lg:h-[19px] mt-[3.5px] md:mt-[4.3px] lg:mt-[5.3px]"></div>
+                  <p className="text-[10px] sm:text-[12px] md:text-[14px] lg:text-[16px] mt-[2.5px] text-[#757575]">
+                    연<span className="font-nanum-bold"> {plan.yearPrice}</span>
+                    원
+                  </p>
+                </div>
+              )}
+              <h1 className="text-[12px] sm:text-[14px] md:text-[16px]">
+                월 토큰 한도:{" "}
+                <span className="font-nanum-bold">{plan.monthTokenLimit}</span>{" "}
+                {plan.name !== "Pro" && "토큰"}
               </h1>
             </div>
-            <div className="mt-[10px] h-[140px] md:h-[160px] flex flex-col gap-[3px]">
-              {plan.features.map((feature) => (
+            <div className="h-[200px] md:h-[210px] flex flex-col gap-[3px]">
+              {Object.entries(plan.features).map(([key, value]) => (
                 <span
-                  key={feature}
-                  className="flex items-start gap-[4px] sm:gap-[7px] text-[12px] sm:text-[14px] md:text-[16px]"
+                  key={value}
+                  className="flex items-start gap-[4px] sm:gap-[7px] text-[13px] sm:text-[14px] md:text-[16px]"
                 >
                   <Image
                     src="/icons/check_black.svg"
@@ -51,16 +71,19 @@ const PricingPlan = () => {
                     height={12}
                     className="shrink-0 mt-[5px] w-[10px] h-[10px] md:w-[12px] md:h-[12px]"
                   />
-                  <p
-                    dangerouslySetInnerHTML={{
-                      __html: `${feature}`,
-                    }}
-                  ></p>
+                  <div>
+                    <p className="font-nanum-extrabold">{key}</p>
+                    <p
+                      dangerouslySetInnerHTML={{
+                        __html: `${value}`,
+                      }}
+                    ></p>
+                  </div>
                 </span>
               ))}
             </div>
             <Link
-              href="/pay"
+              href={isLogin ? "/pay" : "/login"}
               className="text-center rounded-full bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] text-white py-[8px] md:py-[10px] text-[13px] sm:text-[15px] md:text-[17px] font-nanum-bold [filter:drop-shadow(0px_0px_4px_rgba(119,82,254,1))] hover:[filter:drop-shadow(0px_0px_8px_rgba(119,82,254,1))]"
             >
               {isLogin && planTier === plan.name

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -15,8 +15,8 @@ const Header = () => {
   const { mutate: logoutMutate } = useMutation({
     mutationKey: ["logout"],
     mutationFn: logout,
-    onSuccess: (response) => {
-      console.log("✅ 로그아웃 성공", response);
+    onSuccess: (data) => {
+      console.log("✅ 로그아웃 성공", data);
       authLogout();
     },
     onError: (err) => {

--- a/src/components/layout/MobileHeader.tsx
+++ b/src/components/layout/MobileHeader.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useNavbarStore } from "@/stores/navbar.store";
+import Image from "next/image";
+import Link from "next/link";
+import React from "react";
+
+const MobileHeader = () => {
+  const openNavbar = useNavbarStore((s) => s.openNavbar);
+
+  return (
+    <header className="relative z-50 flex py-[10px] justify-center items-center bg-main">
+      <button onClick={openNavbar} className="absolute left-[5%] top-[33%]">
+        <Image src="/icons/menu.svg" alt="menu" width={25} height={25} />
+      </button>
+      <Link
+        href="/"
+        className="font-ghanachoco text-[28px] text-white [text-shadow:2px_4px_4px_rgba(0,0,0,0.5)]"
+      >
+        Phraiz
+      </Link>
+    </header>
+  );
+};
+
+export default MobileHeader;

--- a/src/components/layout/MobileNavBar.tsx
+++ b/src/components/layout/MobileNavBar.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { logout } from "@/apis/logout.api";
+import { SERVICE_LINK } from "@/constants/serviceLink";
+import { useAuthStore } from "@/stores/auth.store";
+import { useNavbarStore } from "@/stores/navbar.store";
+import { useMutation } from "@tanstack/react-query";
+import clsx from "clsx";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const MobileNavBar = () => {
+  const pathname = usePathname();
+  const isLogin = useAuthStore((s) => s.isLogin);
+  const authLogout = useAuthStore((s) => s.logout);
+  const userName = useAuthStore((s) => s.userName);
+  const isOpenNavbar = useNavbarStore((s) => s.isOpenNavbar);
+  const closeNavbar = useNavbarStore((s) => s.closeNavbar);
+
+  const { mutate: logoutMutate } = useMutation({
+    mutationKey: ["logout"],
+    mutationFn: logout,
+    onMutate: () => {
+      closeNavbar();
+    },
+    onSuccess: (data) => {
+      console.log("✅ 로그아웃 성공", data);
+      authLogout();
+    },
+    onError: (err) => {
+      console.error("❌ 로그아웃 실패: ", err.message);
+      alert(err.message);
+    },
+  });
+
+  return (
+    <div
+      className={clsx(
+        "fixed inset-0 z-[9998] flex transition-opacity duration-300",
+        isOpenNavbar ? "opacity-100" : "opacity-0 pointer-events-none"
+      )}
+    >
+      <div onClick={closeNavbar} className="flex-1 bg-black/50" />
+      <aside
+        className={clsx(
+          "absolute inset-0 z-[9999] bg-main min-h-screen h-full py-[20px] px-[25px] flex flex-col gap-[50px] w-[240px] flex-shrink-0",
+          "transform transition-transform duration-300 ease-in-out",
+          isOpenNavbar ? "translate-x-0" : "-translate-x-full"
+        )}
+      >
+        {isLogin ? (
+          <Link
+            onClick={closeNavbar}
+            href="/my"
+            className="flex items-center gap-[4px] ml-[8px]"
+          >
+            <Image src="/icons/avatar.svg" alt="" width={18} height={18} />
+            <p className="text-white text-[18px] font-nanum-bold">
+              {userName!} 님
+            </p>
+          </Link>
+        ) : (
+          <div className="flex ml-[7px] gap-[30px] text-white text-[16px]">
+            <Link
+              onClick={closeNavbar}
+              href="/login"
+              className="font-nanum-extrabold"
+            >
+              로그인
+            </Link>
+            <Link
+              onClick={closeNavbar}
+              href="/sign-up"
+              className="font-nanum-extrabold"
+            >
+              회원가입
+            </Link>
+          </div>
+        )}
+        <div className="flex flex-1 flex-col gap-[20px]">
+          {SERVICE_LINK.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              onClick={closeNavbar}
+              className="flex items-center gap-[5px]"
+            >
+              <Image
+                src={link.icon}
+                alt={link.alt}
+                width={69}
+                height={46}
+                priority
+                className={clsx(
+                  pathname === link.href
+                    ? "[filter:drop-shadow(4px_4px_4px_rgba(0,0,0,0.5))]"
+                    : "[filter:drop-shadow(4px_4px_4px_rgba(0,0,0,0.25))]",
+                  link.label === "AI 요약" && "ml-[-4px]"
+                )}
+              />
+              <p
+                className={clsx(
+                  "text-[18px] font-nanum-bold mt-[6px]",
+                  pathname === link.href &&
+                    "font-nanum-extrabold [text-shadow:2px_2px_4px_rgba(0,0,0,0.25)]",
+                  link.label === "AI 요약" && "ml-[4px]"
+                )}
+              >
+                {link.label}
+              </p>
+            </Link>
+          ))}
+        </div>
+        {isLogin && (
+          <button
+            onClick={() => logoutMutate()}
+            className="text-white text-[12px] font-nanum-extrabold self-start"
+          >
+            로그아웃
+          </button>
+        )}
+      </aside>
+    </div>
+  );
+};
+
+export default MobileNavBar;

--- a/src/components/ui/select/SelectScrollable.tsx
+++ b/src/components/ui/select/SelectScrollable.tsx
@@ -32,7 +32,8 @@ export const SelectScrollable = ({
       <SelectTrigger
         className={cn(
           // shadcn Input과 유사한 스타일 적용
-          "flex h-9 rounded-md border border-input bg-transparent px-3 py-1 shadow-sm transition-colors",
+          "flex w-full md:w-2/3 lg:w-1/2 h-[26px] sm:h-[30px] md:h-[36px] rounded-md border border-input bg-transparent px-3 py-1 shadow-sm transition-colors",
+          "text-[12px] sm:text-[14px] md:text-[16px]",
           "placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",
           "justify-between items-center" // 아이콘과 값 사이 정렬을 위해 추가
@@ -75,7 +76,7 @@ export const SelectScrollable = ({
                     <strong className="font-nanum-bold">{form.name}</strong>{" "}
                     {form.fullName && `(${form.fullName})`}
                   </p>
-                  <span className="ml-2 whitespace-nowrap rounded-md bg-accent px-2 py-0.5 text-xs text-muted-foreground">
+                  <span className="ml-2 whitespace-nowrap rounded-md bg-accent px-2 py-0.5 text-[9px] sm:text-[10px] md:text-[11px] lg:text-[12px] text-muted-foreground">
                     {form.description}
                   </span>
                 </div>

--- a/src/components/ui/select/select.tsx
+++ b/src/components/ui/select/select.tsx
@@ -1,16 +1,16 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as SelectPrimitive from "@radix-ui/react-select"
-import { Check, ChevronDown, ChevronUp } from "lucide-react"
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Select = SelectPrimitive.Root
+const Select = SelectPrimitive.Root;
 
-const SelectGroup = SelectPrimitive.Group
+const SelectGroup = SelectPrimitive.Group;
 
-const SelectValue = SelectPrimitive.Value
+const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
@@ -29,8 +29,8 @@ const SelectTrigger = React.forwardRef<
       <ChevronDown className="h-4 w-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
@@ -46,8 +46,8 @@ const SelectScrollUpButton = React.forwardRef<
   >
     <ChevronUp className="h-4 w-4" />
   </SelectPrimitive.ScrollUpButton>
-))
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
 const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
@@ -63,9 +63,9 @@ const SelectScrollDownButton = React.forwardRef<
   >
     <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
-))
+));
 SelectScrollDownButton.displayName =
-  SelectPrimitive.ScrollDownButton.displayName
+  SelectPrimitive.ScrollDownButton.displayName;
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
@@ -96,8 +96,8 @@ const SelectContent = React.forwardRef<
       <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
@@ -108,8 +108,8 @@ const SelectLabel = React.forwardRef<
     className={cn("px-2 py-1.5 text-sm font-semibold", className)}
     {...props}
   />
-))
-SelectLabel.displayName = SelectPrimitive.Label.displayName
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
@@ -130,8 +130,8 @@ const SelectItem = React.forwardRef<
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
@@ -142,8 +142,8 @@ const SelectSeparator = React.forwardRef<
     className={cn("-mx-1 my-1 h-px bg-muted", className)}
     {...props}
   />
-))
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {
   Select,
@@ -156,4 +156,4 @@ export {
   SelectSeparator,
   SelectScrollUpButton,
   SelectScrollDownButton,
-}
+};

--- a/src/constants/pricingPlan.ts
+++ b/src/constants/pricingPlan.ts
@@ -1,45 +1,61 @@
 export type PricingPlan = {
   name: string;
-  price: number;
-  features: string[];
+  monthPrice?: string;
+  yearPrice?: string;
+  monthTokenLimit: string;
+  features: Record<string, string>;
 };
 
 export const PRICING_PLAN: PricingPlan[] = [
   {
     name: "Free",
-    price: 0,
-    features: [
-      "기본 기능 모두 제공",
-      "광고 포함, <b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>기능별 1일 3회까지 무제한</b>",
-      "초과 시 500자 제한",
-    ],
+    monthTokenLimit: "100,000",
+    features: {
+      "AI 문장 변환": "표준·학술적·창의적·유창성·실험적<br />모드",
+      "AI 요약": "한줄·전체·문단별·핵심 요약",
+      "인용 생성": "각 기능별 30개 제한 저장",
+    },
   },
   {
     name: "Basic",
-    price: 5900,
-    features: [
-      "<b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>GPT-4 Turbo</b> 적용으로<br>더 자연스러운 결과",
-      "광고 없음",
-      "자료 정리를 위한 히스토리 폴더 제공",
-      "월 10만 자, 하루 5,000자 제한",
-    ],
+    monthPrice: "4,900",
+    yearPrice: "49,000",
+    monthTokenLimit: "2,900,000",
+    features: {
+      "AI 문장 변환":
+        "표준·학술적·창의적·유창성·실험적·<br /><b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>사용자(Custom)</b> 모드",
+      "AI 요약":
+        "한줄·전체·문단별·핵심·<b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>질문 기반·<br />타겟</b> 요약",
+      "인용 생성":
+        "<b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>무제한 저장, 폴더 생성</b>",
+    },
   },
   {
     name: "Standard",
-    price: 7900,
-    features: [
-      "<b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>패러프레이징 커스텀 모드</b> 제공",
-      "요약 기능 고도화: 타겟 요약 제공",
-      "더 많은 사용량 제공<br>(월 30만 자, 하루 10,000자 제한)",
-    ],
+    monthPrice: "9,900",
+    yearPrice: "99,000",
+    monthTokenLimit: "6,800,000",
+    features: {
+      "AI 문장 변환":
+        "표준·학술적·창의적·유창성·실험적·<br /><b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>사용자(Custom)</b> 모드",
+      "AI 요약":
+        "한줄·전체·문단별·핵심·<b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>질문 기반·<br />타겟</b> 요약",
+      "인용 생성":
+        "<b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>무제한 저장, 폴더 생성</b>",
+    },
   },
   {
     name: "Pro",
-    price: 9900,
-    features: [
-      "모든 기능 <b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>완전 무제한</b>",
-      "표절 탐지 및 신뢰도 분석 기능<br>(추후 제공 예정)",
-      "콘텐츠 제작자, 연구자, 전문가에게<br>적합",
-    ],
+    monthPrice: "12,900",
+    yearPrice: "119,000",
+    monthTokenLimit: "무제한",
+    features: {
+      "AI 문장 변환":
+        "표준·학술적·창의적·유창성·실험적·<br /><b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>사용자(Custom)</b> 모드",
+      "AI 요약":
+        "한줄·전체·문단별·핵심·<b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>질문 기반·<br />타겟</b> 요약",
+      "인용 생성":
+        "<b class='font-nanum-extrabold bg-gradient-to-r from-[#7752fe] via-[#828ffa] to-[#7752fe] bg-clip-text text-transparent'>무제한 저장, 폴더 생성</b>",
+    },
   },
 ];

--- a/src/constants/serviceLink.ts
+++ b/src/constants/serviceLink.ts
@@ -10,6 +10,7 @@ export type ServiceLink = {
   alt: string;
   label: string;
   title: string;
+  preTitle?: string;
   ctaText: string;
   features: ServiceFeature[];
 };
@@ -74,6 +75,7 @@ export const SERVICE_LINK: ServiceLink[] = [
     alt: "인용 생성",
     label: "인용 생성",
     title: "인용 생성 (Citation & Format Converter)",
+    preTitle: "인용 생성<br />(Citation & Format Converter)",
     ctaText: "인용 생성 기능 이용하러 가기",
     features: [
       {

--- a/src/hooks/useLoginForm.ts
+++ b/src/hooks/useLoginForm.ts
@@ -31,10 +31,10 @@ const useLoginForm = (): LoginFormState & LoginFormActions => {
   const { mutate: loginMutate, isPending: isLoggingIn } = useMutation({
     mutationKey: ["selfLogin", id],
     mutationFn: selfLogin,
-    onSuccess: (response) => {
-      login(response.data.accessToken, response.data.id);
-      console.log("✅ 로그인 완료", response);
-      alert(`${response.data.id}님, 안녕하세요!`);
+    onSuccess: (data) => {
+      login(data.accessToken, data.id);
+      console.log("✅ 로그인 완료", data);
+      alert(`${data.id}님, 안녕하세요!`);
       router.push("/"); // 로그인 성공 시 홈페이지로 이동
     },
     onError: (err) => {
@@ -48,7 +48,7 @@ const useLoginForm = (): LoginFormState & LoginFormActions => {
   const handleLogin = (e: React.FormEvent) => {
     e.preventDefault();
     // 모든 필드 입력 확인
-    if (!id || !pw) {
+    if (!id || !id.trim() || !pw || !pw.trim()) {
       alert("아이디와 비밀번호를 모두 입력해주세요.");
       return;
     }

--- a/src/hooks/useSignupForm.ts
+++ b/src/hooks/useSignupForm.ts
@@ -178,8 +178,8 @@ const useSignupForm = (): SignupFormState & SignupFormActions => {
   } = useMutation({
     mutationKey: ["sendEmail", email],
     mutationFn: sendEmail,
-    onSuccess: (response) => {
-      console.log("✅ 인증번호 전송 성공", response);
+    onSuccess: (data) => {
+      console.log("✅ 인증번호 전송 성공", data);
       alert("입력하신 이메일로 인증번호가 전송되었습니다.");
     },
     onError: (err) => {

--- a/src/stores/navbar.store.ts
+++ b/src/stores/navbar.store.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface NavbarState {
+  isOpenNavbar: boolean;
+  openNavbar: () => void;
+  closeNavbar: () => void;
+  toggleNavbar: () => void;
+}
+
+export const useNavbarStore = create<NavbarState>((set) => ({
+  isOpenNavbar: false,
+  openNavbar: () => set({ isOpenNavbar: true }),
+  closeNavbar: () => set({ isOpenNavbar: false }),
+  toggleNavbar: () => set((state) => ({ isOpenNavbar: !state.isOpenNavbar })),
+}));

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -11,3 +11,25 @@ export type CheckEmailNumberType = {
   email: string;
   emailNum: string;
 };
+
+export type ResetPasswordType = {
+  token: string;
+  newPwd: string;
+};
+
+export type LoginResponseData = {
+  accessToken: string;
+  memberId: number;
+  id: string;
+  email: string;
+  role: string;
+};
+
+export type SignupResponseData = {
+  memberId: number;
+  message: string;
+};
+
+export type CheckIdResponseData = {
+  result: boolean;
+};

--- a/src/types/citation.type.ts
+++ b/src/types/citation.type.ts
@@ -1,0 +1,33 @@
+export type SendUrlType = {
+  url: string;
+  session: string;
+};
+
+export type SendCitationType = {
+  citeId: string;
+  citation: string;
+  style: string;
+};
+
+export type EditCitationFileNameType = {
+  citeId: string;
+  title: string;
+};
+
+export type SendUrlResponseData = {
+  cite_id: number;
+  csl: string;
+};
+
+export type FindCitationHistoryResponseData = {
+  createdAt: string;
+  title: string;
+  citeId: number;
+};
+
+export type ReadDetailCitationInfoResponseData =
+  FindCitationHistoryResponseData & {
+    style: string;
+    citation: string;
+    url: string;
+  };

--- a/src/types/common.type.ts
+++ b/src/types/common.type.ts
@@ -1,0 +1,8 @@
+export type SuccessResponseData = {
+  success: boolean;
+  message: string;
+};
+
+export type Message = {
+  message: string;
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,12 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      screens: {
+        xs: "430px", // 사용자 정의
+        sm: "640px", // 기본값과 동일
+        md: "768px", // 기본값과 동일
+        lg: "1024px", // 기본값과 동일
+      },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",


### PR DESCRIPTION
## ✨ 주요 작업 내용

### 1. `tailwind.config.ts` 파일에 반응형 breakpoint 설정 및 레이아웃 적용

- `tailwind.config.ts` 파일에 `xs`, `sm`, `md`, `lg` 총 4개의 breakpoint를 명시했습니다.
- 메인 페이지, 인용 생성 페이지, 로그인 페이지, 회원가입 페이지에 반응형 레이아웃을 적용하였습니다.
- 화면 너비가 `md` 미만일 경우, 데스크톱 사이드바는 사라지고 모바일 헤더로 자동 전환되며, 메뉴는 왼쪽 상단 아이콘을 클릭해 확인할 수 있습니다.

### 2. 인용문 기능 관련 API 함수 구현

- 인용문 생성, 인용 내역 불러오기 등 주요 기능의 API 함수만 우선 구현했습니다.
- 서버 문제로 인해 실제 테스트는 진행하지 못해, 로직 완성은 추후 테스트 후 예정입니다.

### 3. 비밀번호 재설정 기능 관련 API 함수 구현

- 토큰 기반 비밀번호 재설정 로직을 위한 API 함수 구현 완료
- 서버 연결 문제로 아직 동작 테스트는 진행하지 못한 상태입니다.

## 📢 안내 사항

- `tailwind.config.ts`의 `screens` 속성에 반응형 구현을 위한 breakpoint를 설정해두었습니다.
    - `xs`: 사용자 정의 breakpoint (모바일 대응 목적)
    - `sm`, `md`, `lg`: Tailwind 기본 breakpoint 명시
- 인용 생성 페이지의 Select 박스 클릭 시, 또는 사이드바에서 기록 검색(돋보기 버튼) 클릭 시 **스크롤이 사라지는 이슈**가 여전히 해결되지 않았습니다. `shadcn/ui` 컴포넌트를 사용한 구현 방식에서 발생한 문제로, 최대한 유지하려 했으나 어려움이 있어 **해당 컴포넌트를 제거하거나 교체하는 방향**으로 검토 중입니다.
- 인용 기능 구현을 위해 고유 세션 식별자 생성 라이브러리 `uuid`를 설치해두었습니다. **반드시 `npm install` 후 작업 진행 부탁드립니다!**

## 👀 리뷰 요청 사항

- 메인 / 로그인 / 회원가입 / 인용 생성 페이지의 반응형 레이아웃이 정상적으로 작동하는지 확인 부탁드립니다.
- 특히 모바일 환경에서 사용 시 불편한 UI 요소는 없는지 테스트해주시면 감사하겠습니다.

## 🚀 다음 작업

- `citation.js`를 활용한 인용문 생성 기능 및 프론트 연동 구현
- 인용 생성 페이지 UI 개선 (디자인 및 편의성 향상)
- 결제 페이지 와이어프레임 설계 및 초기 구현