### PR TITLE
[feat] 히스토리/폴더 조회 구현

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,7 +1,7 @@
 import { useAuthStore } from "@/stores/auth.store";
 import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
 
-export const BASE_URL = "http://52.79.34.104/api";
+export const BASE_URL = "https://api.phraiz.com/api";
 
 export const api = axios.create({
   baseURL: BASE_URL,

--- a/src/apis/folder.api.ts
+++ b/src/apis/folder.api.ts
@@ -1,0 +1,108 @@
+import axios from "axios";
+import { api } from "./api";
+import { FolderId, FolderList, PageAndSize } from "@/types/folder.type";
+import { Service } from "@/types/common.type";
+
+// 폴더 목록 불러오기
+export const findFolderList = async ({
+  service,
+  page,
+  size,
+}: Service & PageAndSize): Promise<FolderList> => {
+  const path = `/${service}/folders`;
+  try {
+    const response = await api.get<FolderList>(path, {
+      params: { page: page ?? undefined, size: size ?? undefined },
+    });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[findFolderList] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[findFolderList] Axios 에러: ", error);
+    } else {
+      console.error("[findFolderList] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 폴더 생성
+export const createFolder = async ({
+  service,
+  name,
+}: Service & { name: string }) => {
+  const path = `/${service}/folders`;
+  try {
+    const response = await api.post(path, { name });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[createFolder] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[createFolder] Axios 에러: ", error);
+    } else {
+      console.error("[createFolder] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 폴더 이름 수정
+export const editFolderName = async ({
+  service,
+  folderId,
+  name,
+}: Service & FolderId & { name: string }) => {
+  const path = `/${service}/folders/${folderId}`;
+  try {
+    const response = await api.patch(path, { name });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[editFolderName] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[editFolderName] Axios 에러: ", error);
+    } else {
+      console.error("[editFolderName] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 폴더 삭제
+export const deleteFolder = async ({
+  service,
+  folderId,
+}: Service & FolderId) => {
+  const path = `/${service}/folders/${folderId}`;
+  try {
+    const response = await api.delete(path);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[deleteFolder] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[deleteFolder] Axios 에러: ", error);
+    } else {
+      console.error("[deleteFolder] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};

--- a/src/apis/history.api.ts
+++ b/src/apis/history.api.ts
@@ -1,0 +1,165 @@
+import { Service } from "@/types/common.type";
+import {
+  FolderIdWithPageAndSize,
+  HistoryAndFolderId,
+  HistoryId,
+  HistoryList,
+} from "@/types/history.type";
+import { api } from "./api";
+import axios from "axios";
+import { FolderId } from "@/types/folder.type";
+
+// 히스토리 목록 불러오기
+export const findHistoryList = async ({
+  service,
+  folderId,
+  page,
+  size,
+}: Service & FolderIdWithPageAndSize): Promise<HistoryList> => {
+  const path = folderId
+    ? `/${service}/histories/${folderId}`
+    : `/${service}/histories`;
+  try {
+    const response = await api.get<HistoryList>(path, {
+      params: { page: page ?? undefined, size: size ?? undefined },
+    });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[findHistoryList] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[findHistoryList] Axios 에러: ", error);
+    } else {
+      console.error("[findHistoryList] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 히스토리 생성
+export const createHistory = async ({
+  service,
+  folderId,
+  name,
+}: Service & FolderId & { name: string }) => {
+  const path = folderId
+    ? `/${service}/histories/${folderId}`
+    : `/${service}/histories`;
+  try {
+    const response = await api.post(path, { name });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[createHistory] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[createHistory] Axios 에러: ", error);
+    } else {
+      console.error("[createHistory] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 히스토리 이름 수정
+export const editHistoryName = async ({
+  service,
+  historyId,
+  name,
+}: Service & HistoryId & { name: string }) => {
+  const path = `/${service}/histories/${historyId}`;
+  try {
+    const response = await api.patch(path, { name });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[editHistoryName] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[editHistoryName] Axios 에러: ", error);
+    } else {
+      console.error("[editHistoryName] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 히스토리 이동(폴더 변경)
+export const moveFolder = async ({
+  service,
+  historyId,
+  folderId,
+}: Service & HistoryAndFolderId) => {
+  const path = `/${service}/histories/${historyId}`;
+  try {
+    const response = await api.patch(path, { folderId });
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error("[moveFolder] Axios 에러: ", error.response.data.message);
+        throw new Error(error.response.data.message);
+      } else console.error("[moveFolder] Axios 에러: ", error);
+    } else {
+      console.error("[moveFolder] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 히스토리 삭제
+export const deleteHistory = async ({
+  service,
+  historyId,
+}: Service & HistoryId) => {
+  const path = `/${service}/histories/${historyId}`;
+  try {
+    const response = await api.delete(path);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error("[moveFolder] Axios 에러: ", error.response.data.message);
+        throw new Error(error.response.data.message);
+      } else console.error("[moveFolder] Axios 에러: ", error);
+    } else {
+      console.error("[moveFolder] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};
+
+// 히스토리 최신 내용 조회
+export const readLatestHistory = async ({
+  service,
+  historyId,
+}: Service & HistoryId) => {
+  const path = `/${service}/histories/${historyId}/latest`;
+  try {
+    const response = await api.get(path);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response?.data.code) {
+        console.error(
+          "[readLatestHistory] Axios 에러: ",
+          error.response.data.message
+        );
+        throw new Error(error.response.data.message);
+      } else console.error("[readLatestHistory] Axios 에러: ", error);
+    } else {
+      console.error("[readLatestHistory] 일반 에러: ", error);
+    }
+    throw error;
+  }
+};

--- a/src/components/box/AiParaphraseBox.tsx
+++ b/src/components/box/AiParaphraseBox.tsx
@@ -7,13 +7,26 @@ import { requestParaphrase, ParaphraseApiMode } from "@/apis/paraphrase.api";
 import Image from "next/image";
 import { useAuthStore } from "@/stores/auth.store";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 
 const HEADER_H = 72; // px
 
 // 모드 선택 버튼 타입 정의
-type ParaphraseMode = "표준" | "학술적" | "창의적" | "유창성" | "문학적" | "사용자 지정";
+type ParaphraseMode =
+  | "표준"
+  | "학술적"
+  | "창의적"
+  | "유창성"
+  | "문학적"
+  | "사용자 지정";
 
-const ToneBlendSlider = ({ value, onChange }: { value: number; onChange: (value: number) => void }) => {
+const ToneBlendSlider = ({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (value: number) => void;
+}) => {
   return (
     <div className="w-full bg-blue-50 rounded-lg shadow-2xl p-3">
       {" "}
@@ -39,7 +52,7 @@ const ToneBlendSlider = ({ value, onChange }: { value: number; onChange: (value:
           onChange={(e) => onChange(parseInt(e.target.value))}
           className="absolute top-0 left-0 w-full h-1.5 bg-transparent appearance-none cursor-pointer slider-thumb"
           style={{
-            background: "transparent"
+            background: "transparent",
           }}
         />
       </div>
@@ -55,8 +68,28 @@ const ToneBlendSlider = ({ value, onChange }: { value: number; onChange: (value:
 };
 
 // 모드 선택 버튼 UI 컴포넌트
-const ModeSelector = ({ activeMode, setActiveMode, customStyle, setCustomStyle, creativityLevel, setCreativityLevel }: { activeMode: ParaphraseMode; setActiveMode: (mode: ParaphraseMode) => void; customStyle: string; setCustomStyle: (style: string) => void; creativityLevel: number; setCreativityLevel: (level: number) => void }) => {
-  const modes: ParaphraseMode[] = ["표준", "학술적", "창의적", "유창성", "문학적"];
+const ModeSelector = ({
+  activeMode,
+  setActiveMode,
+  customStyle,
+  setCustomStyle,
+  creativityLevel,
+  setCreativityLevel,
+}: {
+  activeMode: ParaphraseMode;
+  setActiveMode: (mode: ParaphraseMode) => void;
+  customStyle: string;
+  setCustomStyle: (style: string) => void;
+  creativityLevel: number;
+  setCreativityLevel: (level: number) => void;
+}) => {
+  const modes: ParaphraseMode[] = [
+    "표준",
+    "학술적",
+    "창의적",
+    "유창성",
+    "문학적",
+  ];
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
   const customButtonRef = useRef<HTMLButtonElement>(null);
@@ -68,11 +101,21 @@ const ModeSelector = ({ activeMode, setActiveMode, customStyle, setCustomStyle, 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       // 사용자 지정 팝업 퍼리
-      if (popoverRef.current && !popoverRef.current.contains(event.target as Node) && customButtonRef.current && !customButtonRef.current.contains(event.target as Node)) {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(event.target as Node) &&
+        customButtonRef.current &&
+        !customButtonRef.current.contains(event.target as Node)
+      ) {
         setIsPopoverOpen(false);
       }
       // 창의적 슬라이더 팝업 처리
-      if (creativeSliderRef.current && !creativeSliderRef.current.contains(event.target as Node) && creativeButtonRef.current && !creativeButtonRef.current.contains(event.target as Node)) {
+      if (
+        creativeSliderRef.current &&
+        !creativeSliderRef.current.contains(event.target as Node) &&
+        creativeButtonRef.current &&
+        !creativeButtonRef.current.contains(event.target as Node)
+      ) {
         setIsCreativeSliderOpen(false);
       }
     }
@@ -97,27 +140,53 @@ const ModeSelector = ({ activeMode, setActiveMode, customStyle, setCustomStyle, 
     setIsCreativeSliderOpen(false); // 사용자 지정 선택 시 슬라이더 닫기
   };
 
-  const baseButtonClass = "h-9 md:h-11 text-[11px] md:text-sm whitespace-nowrap rounded-full font-medium transition-all flex items-center justify-center shadow-md shadow-neutral-900/20";
-  const inactiveClass = "bg-purple-100 border border-purple-600/30 hover:bg-purple-200/60";
-  const activeClass = "bg-purple-200 border border-purple-600/30 ring-1 ring-purple-300";
+  const baseButtonClass =
+    "h-9 md:h-11 text-[11px] md:text-sm whitespace-nowrap rounded-full font-medium transition-all flex items-center justify-center shadow-md shadow-neutral-900/20";
+  const inactiveClass =
+    "bg-purple-100 border border-purple-600/30 hover:bg-purple-200/60";
+  const activeClass =
+    "bg-purple-200 border border-purple-600/30 ring-1 ring-purple-300";
 
   return (
     <div className="w-full">
       <div className="flex w-full gap-2 md:gap-3">
         {modes.map((mode) => (
           <div key={mode} className="relative flex-1">
-            <button ref={mode === "창의적" ? creativeButtonRef : undefined} onClick={() => handleModeClick(mode)} className={clsx("w-full", baseButtonClass, activeMode === mode ? activeClass : inactiveClass)}>
+            <button
+              ref={mode === "창의적" ? creativeButtonRef : undefined}
+              onClick={() => handleModeClick(mode)}
+              className={clsx(
+                "w-full",
+                baseButtonClass,
+                activeMode === mode ? activeClass : inactiveClass
+              )}
+            >
               {mode}
             </button>
 
             {/* 창의적 모드 슬라이더 팝업 */}
             {mode === "창의적" && isCreativeSliderOpen && (
-              <div ref={creativeSliderRef} className={clsx("absolute top-full mt-4 z-[60] p-0.5", "w-[90vw] max-w-[320px] lg:w-80", "left-1/2 -translate-x-1/2")}>
+              <div
+                ref={creativeSliderRef}
+                className={clsx(
+                  "absolute top-full mt-4 z-[60] p-0.5",
+                  "w-[90vw] max-w-[320px] lg:w-80",
+                  "left-1/2 -translate-x-1/2"
+                )}
+              >
                 <div className="relative">
                   {/* 뾰족한 삼각형 */}
-                  <div className={clsx("absolute -translate-x-1/2 -top-[10px] w-4 h-4 bg-blue-50 border-l-2 border-t-2 rotate-45", "left-1/2")}></div>
+                  <div
+                    className={clsx(
+                      "absolute -translate-x-1/2 -top-[10px] w-4 h-4 bg-blue-50 border-l-2 border-t-2 rotate-45",
+                      "left-1/2"
+                    )}
+                  ></div>
 
-                  <ToneBlendSlider value={creativityLevel} onChange={setCreativityLevel} />
+                  <ToneBlendSlider
+                    value={creativityLevel}
+                    onChange={setCreativityLevel}
+                  />
                 </div>
               </div>
             )}
@@ -125,16 +194,50 @@ const ModeSelector = ({ activeMode, setActiveMode, customStyle, setCustomStyle, 
         ))}
         {/* 사용자 지정 버튼, 팝업 */}
         <div className="relative flex-1">
-          <button ref={customButtonRef} onClick={handleCustomClick} className={clsx("w-full", baseButtonClass, "relative gap-2", activeMode === "사용자 지정" ? activeClass : inactiveClass)}>
+          <button
+            ref={customButtonRef}
+            onClick={handleCustomClick}
+            className={clsx(
+              "w-full",
+              baseButtonClass,
+              "relative gap-2",
+              activeMode === "사용자 지정" ? activeClass : inactiveClass
+            )}
+          >
             사용자 지정
-            <Image src="/icons/프리미엄2.svg" alt="" width={0} height={0} className="absolute w-[30px] h-[30px] top-[-12px] right-[-5px] md:w-[45px] md:h-[45px] md:top-[-20px] md:right-[-6px]" />
+            <Image
+              src="/icons/프리미엄2.svg"
+              alt=""
+              width={0}
+              height={0}
+              className="absolute w-[30px] h-[30px] top-[-12px] right-[-5px] md:w-[45px] md:h-[45px] md:top-[-20px] md:right-[-6px]"
+            />
           </button>
           {isPopoverOpen && (
-            <div ref={popoverRef} className={clsx("absolute top-full mt-4 z-50 p-0.5", "w-[90vw] max-w-[320px] lg:w-80", "right-0 lg:left-1/2 lg:-translate-x-1/2 lg:right-auto")}>
+            <div
+              ref={popoverRef}
+              className={clsx(
+                "absolute top-full mt-4 z-50 p-0.5",
+                "w-[90vw] max-w-[320px] lg:w-80",
+                "right-0 lg:left-1/2 lg:-translate-x-1/2 lg:right-auto"
+              )}
+            >
               <div className="relative bg-blue-50 rounded-lg shadow-2xl p-3">
-                <div className={clsx("absolute -translate-x-1/2 -top-[10px] w-4 h-4 bg-blue-50 border-l-2 border-t-2 rotate-45", "left-[calc(100%-30px)] lg:left-1/2")}></div>
-                <p className="text-sm text-gray-600 mb-2">원하는 문장 스타일을 입력하세요. (50자 이내)</p>
-                <textarea value={customStyle} onChange={(e) => setCustomStyle(e.target.value)} maxLength={50} className="w-full h-32 p-2 border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-purple-400" />
+                <div
+                  className={clsx(
+                    "absolute -translate-x-1/2 -top-[10px] w-4 h-4 bg-blue-50 border-l-2 border-t-2 rotate-45",
+                    "left-[calc(100%-30px)] lg:left-1/2"
+                  )}
+                ></div>
+                <p className="text-sm text-gray-600 mb-2">
+                  원하는 문장 스타일을 입력하세요. (50자 이내)
+                </p>
+                <textarea
+                  value={customStyle}
+                  onChange={(e) => setCustomStyle(e.target.value)}
+                  maxLength={50}
+                  className="w-full h-32 p-2 border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-purple-400"
+                />
               </div>
             </div>
           )}
@@ -152,7 +255,10 @@ const AiParaphraseBox = () => {
       ticking = true;
       requestAnimationFrame(() => {
         const offset = Math.max(HEADER_H - window.scrollY, 0);
-        document.documentElement.style.setProperty("--header-offset", `${offset}px`);
+        document.documentElement.style.setProperty(
+          "--header-offset",
+          `${offset}px`
+        );
         ticking = false;
       });
     };
@@ -171,6 +277,7 @@ const AiParaphraseBox = () => {
 
   const isLogin = useAuthStore((s) => s.isLogin);
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const handleApiCall = async () => {
     if (!isLogin) {
@@ -188,19 +295,22 @@ const AiParaphraseBox = () => {
       창의적: "creative",
       유창성: "fluency",
       문학적: "experimental",
-      "사용자 지정": "custom"
+      "사용자 지정": "custom",
     };
     const apiMode = modeMap[activeMode];
 
     const requestData = {
       text: inputText,
       userRequestMode: activeMode === "사용자 지정" ? customStyle : undefined,
-      creativityLevel: activeMode === "창의적" ? creativityLevel : undefined
+      creativityLevel: activeMode === "창의적" ? creativityLevel : undefined,
     };
 
     try {
       const response = await requestParaphrase(apiMode, requestData);
       setOutputText(response.result);
+      queryClient.invalidateQueries({
+        queryKey: ["sidebar-history", "paraphrase"],
+      });
     } catch (error) {
       console.error("API 요청 오류:", error);
       setOutputText("오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
@@ -212,24 +322,55 @@ const AiParaphraseBox = () => {
   return (
     <div className="w-full flex flex-col h-full p-2 md:p-4 gap-2 md:gap-4">
       <header className="flex justify-between items-center px-[3px]">
-        <h1 className="text-lg md:text-2xl font-bold text-gray-800">AI 문장 변환</h1>
+        <h1 className="text-lg md:text-2xl font-bold text-gray-800">
+          AI 문장 변환
+        </h1>
       </header>
       <div className="px-[3px]">
-        <ModeSelector activeMode={activeMode} setActiveMode={setActiveMode} customStyle={customStyle} setCustomStyle={setCustomStyle} creativityLevel={creativityLevel} setCreativityLevel={setCreativityLevel} />
+        <ModeSelector
+          activeMode={activeMode}
+          setActiveMode={setActiveMode}
+          customStyle={customStyle}
+          setCustomStyle={setCustomStyle}
+          creativityLevel={creativityLevel}
+          setCreativityLevel={setCreativityLevel}
+        />
       </div>
-      <div className={clsx("flex flex-col md:flex-row", "flex-1 rounded-lg shadow-lg overflow-hidden border bg-white")}>
+      <div
+        className={clsx(
+          "flex flex-col md:flex-row",
+          "flex-1 rounded-lg shadow-lg overflow-hidden border bg-white"
+        )}
+      >
         <div className="w-full h-1/2 md:h-full md:w-1/2 border-b md:border-b-0 md:border-r p-2 md:p-4 flex flex-col">
-          <textarea value={inputText} onChange={(e) => setInputText(e.target.value)} placeholder="내용을 입력하세요." className="flex-1 w-full resize-none outline-none text-sm md:text-base" disabled={isLoading}></textarea>
+          <textarea
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+            placeholder="내용을 입력하세요."
+            className="flex-1 w-full resize-none outline-none text-sm md:text-base"
+            disabled={isLoading}
+          ></textarea>
           <div className="flex justify-end items-center mt-2 md:mt-4">
-            <button onClick={handleApiCall} className="py-1.5 px-4 md:py-2 md:px-6 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:bg-gray-400 font-semibold text-xs md:text-base" disabled={isLoading || !inputText.trim()}>
+            <button
+              onClick={handleApiCall}
+              className="py-1.5 px-4 md:py-2 md:px-6 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:bg-gray-400 font-semibold text-xs md:text-base"
+              disabled={isLoading || !inputText.trim()}
+            >
               {isLoading ? "변환 중..." : "변환하기"}
             </button>
           </div>
         </div>
         <div className="w-full h-1/2 md:h-full md:w-1/2 p-2 md:p-4 relative bg-gray-50">
-          <div className="w-full h-full whitespace-pre-wrap text-gray-800 pr-10 text-sm md:text-base">{isLoading ? "결과 생성 중..." : outputText || "여기에 변환 결과가 표시됩니다."}</div>
+          <div className="w-full h-full whitespace-pre-wrap text-gray-800 pr-10 text-sm md:text-base">
+            {isLoading
+              ? "결과 생성 중..."
+              : outputText || "여기에 변환 결과가 표시됩니다."}
+          </div>
           {outputText && (
-            <button onClick={() => navigator.clipboard.writeText(outputText)} className="absolute top-3 right-3 p-2 text-gray-500 hover:bg-gray-200 rounded-full">
+            <button
+              onClick={() => navigator.clipboard.writeText(outputText)}
+              className="absolute top-3 right-3 p-2 text-gray-500 hover:bg-gray-200 rounded-full"
+            >
               <Copy className="h-4 w-4" />
             </button>
           )}

--- a/src/components/box/AiSummarizeBox.tsx
+++ b/src/components/box/AiSummarizeBox.tsx
@@ -7,15 +7,42 @@ import { requestSummarize, SummarizeApiMode } from "@/apis/summarize.api";
 import Image from "next/image";
 import { useAuthStore } from "@/stores/auth.store";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 
 const HEADER_H = 72; // px
 
 // 모드 선택 버튼 타입 정의
-type SummarizeMode = "한줄 요약" | "전체 요약" | "문단별 요약" | "핵심 요약" | "질문 기반 요약" | "타겟 요약";
+type SummarizeMode =
+  | "한줄 요약"
+  | "전체 요약"
+  | "문단별 요약"
+  | "핵심 요약"
+  | "질문 기반 요약"
+  | "타겟 요약";
 
 // 모드 선택 버튼 UI 컴포넌트
-const ModeSelector = ({ activeMode, setActiveMode, targetAudience, setTargetAudience, questionText, setQuestionText }: { activeMode: SummarizeMode; setActiveMode: (mode: SummarizeMode) => void; targetAudience: string; setTargetAudience: (style: string) => void; questionText: string; setQuestionText: (text: string) => void }) => {
-  const modes: SummarizeMode[] = ["한줄 요약", "전체 요약", "문단별 요약", "핵심 요약", "질문 기반 요약"];
+const ModeSelector = ({
+  activeMode,
+  setActiveMode,
+  targetAudience,
+  setTargetAudience,
+  questionText,
+  setQuestionText,
+}: {
+  activeMode: SummarizeMode;
+  setActiveMode: (mode: SummarizeMode) => void;
+  targetAudience: string;
+  setTargetAudience: (style: string) => void;
+  questionText: string;
+  setQuestionText: (text: string) => void;
+}) => {
+  const modes: SummarizeMode[] = [
+    "한줄 요약",
+    "전체 요약",
+    "문단별 요약",
+    "핵심 요약",
+    "질문 기반 요약",
+  ];
 
   // 타겟 요약 팝업 상태
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -31,12 +58,22 @@ const ModeSelector = ({ activeMode, setActiveMode, targetAudience, setTargetAudi
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
       // 타겟 요약 팝업 닫기
-      if (popoverRef.current && !popoverRef.current.contains(event.target as Node) && customButtonRef.current && !customButtonRef.current.contains(event.target as Node)) {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(event.target as Node) &&
+        customButtonRef.current &&
+        !customButtonRef.current.contains(event.target as Node)
+      ) {
         setIsPopoverOpen(false);
       }
 
       // 질문 팝업 닫기
-      if (questionPopoverRef.current && !questionPopoverRef.current.contains(event.target as Node) && questionButtonRef.current && !questionButtonRef.current.contains(event.target as Node)) {
+      if (
+        questionPopoverRef.current &&
+        !questionPopoverRef.current.contains(event.target as Node) &&
+        questionButtonRef.current &&
+        !questionButtonRef.current.contains(event.target as Node)
+      ) {
         setIsQuestionPopoverOpen(false);
       }
     }
@@ -64,25 +101,55 @@ const ModeSelector = ({ activeMode, setActiveMode, targetAudience, setTargetAudi
     setIsQuestionPopoverOpen(false); // 다른 팝업은 닫기
   };
 
-  const baseButtonClass = "h-9 md:h-11 text-[11px] md:text-sm whitespace-nowrap rounded-full font-medium transition-all flex items-center justify-center shadow-md shadow-neutral-900/20";
-  const inactiveClass = "bg-purple-100 border border-purple-600/30 hover:bg-purple-200/60";
-  const activeClass = "bg-purple-200 border border-purple-600/30 ring-1 ring-purple-300";
+  const baseButtonClass =
+    "h-9 md:h-11 text-[11px] md:text-sm whitespace-nowrap rounded-full font-medium transition-all flex items-center justify-center shadow-md shadow-neutral-900/20";
+  const inactiveClass =
+    "bg-purple-100 border border-purple-600/30 hover:bg-purple-200/60";
+  const activeClass =
+    "bg-purple-200 border border-purple-600/30 ring-1 ring-purple-300";
 
   return (
     <div className="flex w-full gap-2 md:gap-3 relative">
       {modes.map((mode) => (
         <div key={mode} className="relative flex-1">
-          <button ref={mode === "질문 기반 요약" ? questionButtonRef : undefined} onClick={() => handleModeClick(mode)} className={clsx("w-full", baseButtonClass, activeMode === mode ? activeClass : inactiveClass)}>
+          <button
+            ref={mode === "질문 기반 요약" ? questionButtonRef : undefined}
+            onClick={() => handleModeClick(mode)}
+            className={clsx(
+              "w-full",
+              baseButtonClass,
+              activeMode === mode ? activeClass : inactiveClass
+            )}
+          >
             {mode}
           </button>
 
           {/* 질문 기반 요약 팝업 */}
           {mode === "질문 기반 요약" && isQuestionPopoverOpen && (
-            <div ref={questionPopoverRef} className={clsx("absolute top-full mt-4 z-[60] p-0.5", "w-[90vw] max-w-[320px] lg:w-80", "right-0 lg:left-1/2 lg:-translate-x-1/2 lg:right-auto")}>
+            <div
+              ref={questionPopoverRef}
+              className={clsx(
+                "absolute top-full mt-4 z-[60] p-0.5",
+                "w-[90vw] max-w-[320px] lg:w-80",
+                "right-0 lg:left-1/2 lg:-translate-x-1/2 lg:right-auto"
+              )}
+            >
               <div className="relative bg-blue-50 rounded-lg shadow-2xl p-3">
-                <div className={clsx("absolute -translate-x-1/2 -top-[10px] w-4 h-4 bg-blue-50 border-l-2 border-t-2 rotate-45", "left-[calc(100%-30px)] lg:left-1/2")}></div>
-                <p className="text-sm text-gray-600 mb-2">요약할 때 답변받고 싶은 질문을 입력하세요. (100자 이내)</p>
-                <textarea value={questionText} onChange={(e) => setQuestionText(e.target.value)} maxLength={100} className="w-full h-32 p-2 border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-purple-400" />
+                <div
+                  className={clsx(
+                    "absolute -translate-x-1/2 -top-[10px] w-4 h-4 bg-blue-50 border-l-2 border-t-2 rotate-45",
+                    "left-[calc(100%-30px)] lg:left-1/2"
+                  )}
+                ></div>
+                <p className="text-sm text-gray-600 mb-2">
+                  요약할 때 답변받고 싶은 질문을 입력하세요. (100자 이내)
+                </p>
+                <textarea
+                  value={questionText}
+                  onChange={(e) => setQuestionText(e.target.value)}
+                  maxLength={100}
+                  className="w-full h-32 p-2 border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-purple-400"
+                />
               </div>
             </div>
           )}
@@ -91,16 +158,50 @@ const ModeSelector = ({ activeMode, setActiveMode, targetAudience, setTargetAudi
 
       {/* 타겟 요약 버튼, 팝업 */}
       <div className="relative flex-1">
-        <button ref={customButtonRef} onClick={handleCustomClick} className={clsx("w-full", baseButtonClass, "relative gap-2", activeMode === "타겟 요약" ? activeClass : inactiveClass)}>
+        <button
+          ref={customButtonRef}
+          onClick={handleCustomClick}
+          className={clsx(
+            "w-full",
+            baseButtonClass,
+            "relative gap-2",
+            activeMode === "타겟 요약" ? activeClass : inactiveClass
+          )}
+        >
           타겟 요약
-          <Image src="/icons/프리미엄2.svg" alt="" width={0} height={0} className="absolute w-[38px] h-[38px] top-[-16px] right-[-5px] md:w-[45px] md:h-[45px] md:top-[-20px] md:right-[-6px]" />
+          <Image
+            src="/icons/프리미엄2.svg"
+            alt=""
+            width={0}
+            height={0}
+            className="absolute w-[38px] h-[38px] top-[-16px] right-[-5px] md:w-[45px] md:h-[45px] md:top-[-20px] md:right-[-6px]"
+          />
         </button>
         {isPopoverOpen && (
-          <div ref={popoverRef} className={clsx("absolute top-full mt-4 z-[60] p-0.5", "w-[90vw] max-w-[320px] lg:w-80", "right-0 lg:left-1/2 lg:-translate-x-1/2 lg:right-auto")}>
+          <div
+            ref={popoverRef}
+            className={clsx(
+              "absolute top-full mt-4 z-[60] p-0.5",
+              "w-[90vw] max-w-[320px] lg:w-80",
+              "right-0 lg:left-1/2 lg:-translate-x-1/2 lg:right-auto"
+            )}
+          >
             <div className="relative bg-blue-50 rounded-lg shadow-2xl p-3">
-              <div className={clsx("absolute -translate-x-1/2 -top-[10px] w-4 h-4 bg-blue-50 border-l-2 border-t-2 rotate-45", "left-[calc(100%-30px)] lg:left-1/2")}></div>
-              <p className="text-sm text-gray-600 mb-2">요약 내용을 전달할 대상을 입력하세요. (20자 이내)</p>
-              <textarea value={targetAudience} onChange={(e) => setTargetAudience(e.target.value)} maxLength={20} className="w-full h-32 p-2 border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-purple-400" />
+              <div
+                className={clsx(
+                  "absolute -translate-x-1/2 -top-[10px] w-4 h-4 bg-blue-50 border-l-2 border-t-2 rotate-45",
+                  "left-[calc(100%-30px)] lg:left-1/2"
+                )}
+              ></div>
+              <p className="text-sm text-gray-600 mb-2">
+                요약 내용을 전달할 대상을 입력하세요. (20자 이내)
+              </p>
+              <textarea
+                value={targetAudience}
+                onChange={(e) => setTargetAudience(e.target.value)}
+                maxLength={20}
+                className="w-full h-32 p-2 border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-purple-400"
+              />
             </div>
           </div>
         )}
@@ -117,7 +218,10 @@ const AiSummarizeBox = () => {
       ticking = true;
       requestAnimationFrame(() => {
         const offset = Math.max(HEADER_H - window.scrollY, 0);
-        document.documentElement.style.setProperty("--header-offset", `${offset}px`);
+        document.documentElement.style.setProperty(
+          "--header-offset",
+          `${offset}px`
+        );
         ticking = false;
       });
     };
@@ -137,6 +241,7 @@ const AiSummarizeBox = () => {
 
   const isLogin = useAuthStore((s) => s.isLogin);
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const handleApiCall = async () => {
     if (!isLogin) {
@@ -155,7 +260,7 @@ const AiSummarizeBox = () => {
       "문단별 요약": "by-paragraph",
       "핵심 요약": "key-points",
       "질문 기반 요약": "question-based",
-      "타겟 요약": "targeted"
+      "타겟 요약": "targeted",
     };
     const apiMode = modeMap[activeMode];
 
@@ -163,13 +268,16 @@ const AiSummarizeBox = () => {
     const requestData = {
       text: inputText,
       question: activeMode === "질문 기반 요약" ? questionText : undefined,
-      target: activeMode === "타겟 요약" ? targetAudience : undefined
+      target: activeMode === "타겟 요약" ? targetAudience : undefined,
     };
 
     try {
       // API 파일을 통해 요청을 보냅니다.
       const response = await requestSummarize(apiMode, requestData);
       setOutputText(response.result); // '.result' 키로 결과값을 사용합니다.
+      queryClient.invalidateQueries({
+        queryKey: ["sidebar-history", "summary"],
+      });
     } catch (error) {
       console.error("API 요청 오류:", error);
       setOutputText("오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
@@ -184,25 +292,56 @@ const AiSummarizeBox = () => {
         <h1 className="text-lg md:text-2xl font-bold text-gray-800">AI 요약</h1>
       </header>
       <div className="px-[3px]">
-        <ModeSelector activeMode={activeMode} setActiveMode={setActiveMode} targetAudience={targetAudience} setTargetAudience={setTargetAudience} questionText={questionText} setQuestionText={setQuestionText} />
+        <ModeSelector
+          activeMode={activeMode}
+          setActiveMode={setActiveMode}
+          targetAudience={targetAudience}
+          setTargetAudience={setTargetAudience}
+          questionText={questionText}
+          setQuestionText={setQuestionText}
+        />
       </div>
-      <div className={clsx("flex flex-col md:flex-row", "flex-1 rounded-lg shadow-lg overflow-hidden border bg-white")}>
+      <div
+        className={clsx(
+          "flex flex-col md:flex-row",
+          "flex-1 rounded-lg shadow-lg overflow-hidden border bg-white"
+        )}
+      >
         <div className="w-full h-1/2 md:h-full md:w-1/2 border-b md:border-b-0 md:border-r p-2 md:p-4 flex flex-col">
-          <textarea value={inputText} onChange={(e) => setInputText(e.target.value)} placeholder="내용을 입력하세요." className="flex-1 w-full resize-none outline-none text-sm md:text-base" disabled={isLoading}></textarea>
+          <textarea
+            value={inputText}
+            onChange={(e) => setInputText(e.target.value)}
+            placeholder="내용을 입력하세요."
+            className="flex-1 w-full resize-none outline-none text-sm md:text-base"
+            disabled={isLoading}
+          ></textarea>
           <div className="flex justify-between items-center mt-2 md:mt-4">
             <button className="flex items-center gap-1 md:gap-[6px]">
               <Image src="/icons/upload.svg" alt="" width={22} height={22} />
-              <p className="hover:font-nanum-bold text-xs md:text-sm">파일 업로드하기</p>
+              <p className="hover:font-nanum-bold text-xs md:text-sm">
+                파일 업로드하기
+              </p>
             </button>
-            <button onClick={handleApiCall} className="py-1.5 px-4 md:py-2 md:px-6 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:bg-gray-400 font-semibold text-xs md:text-base" disabled={isLoading || !inputText.trim()}>
+            <button
+              onClick={handleApiCall}
+              className="py-1.5 px-4 md:py-2 md:px-6 bg-purple-600 text-white rounded-lg hover:bg-purple-700 disabled:bg-gray-400 font-semibold text-xs md:text-base"
+              disabled={isLoading || !inputText.trim()}
+            >
               {isLoading ? "요약 중..." : "요약하기"}
             </button>
           </div>
         </div>
         <div className="w-full h-1/2 md:h-full md:w-1/2 p-2 md:p-4 relative bg-gray-50">
-          <div className="w-full h-full whitespace-pre-wrap text-gray-800 pr-10 text-sm md:text-base">{isLoading ? "요약 생성 중..." : outputText || "여기에 요약 결과가 표시됩니다."}</div>
+          <div className="w-full h-full whitespace-pre-wrap text-gray-800 pr-10 text-sm md:text-base">
+            {isLoading
+              ? "요약 생성 중..."
+              : outputText || "여기에 요약 결과가 표시됩니다."}
+          </div>
           {outputText && (
-            <button onClick={() => navigator.clipboard.writeText(outputText)} className="absolute top-3 right-3 p-2 text-gray-500 hover:bg-gray-200 rounded-full">
+            <button
+              onClick={() => navigator.clipboard.writeText(outputText)}
+              className="absolute top-3 right-3 p-2 text-gray-500 hover:bg-gray-200 rounded-full"
+            >
               <Copy className="h-4 w-4" />
             </button>
           )}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,6 +11,7 @@ const Header = () => {
   const isLogin = useAuthStore((s) => s.isLogin);
   const authLogout = useAuthStore((s) => s.logout);
   const userName = useAuthStore((s) => s.userName);
+  const planTier = useAuthStore((s) => s.planTier);
 
   const { mutate: logoutMutate } = useMutation({
     mutationKey: ["logout"],
@@ -36,7 +37,14 @@ const Header = () => {
       {isLogin ? (
         <div className="flex items-center gap-[15px]">
           <Link href="/pricing-plan" className="flex items-center gap-[4px]">
-            <Image src="/icons/grade_free.png" alt="" width={50} height={50} />
+            {planTier && (
+              <Image
+                src={`/icons/grade_${planTier}.png`}
+                alt=""
+                width={50}
+                height={50}
+              />
+            )}
             <p className="text-white text-[18px] font-nanum-bold ml-[-7px]">
               {userName!} 님
             </p>

--- a/src/components/ui/sidebar/FolderTree.tsx
+++ b/src/components/ui/sidebar/FolderTree.tsx
@@ -2,34 +2,24 @@
 
 import { usePathname } from "next/navigation";
 import TreeNode from "./TreeNode";
-// import { useQuery } from "@tanstack/react-query";
-
-const dummy = [
-  { id: 1, name: "레포트 작성", children: [] },
-  { id: 2, name: "보수사항미완료내기", children: [] },
-  {
-    id: 3,
-    name: "발표 자료",
-    children: [
-      { id: 31, name: "자바 2장 본문 발표" },
-      { id: 32, name: "AI 윤리와 사회적 영향 발표" },
-    ],
-  },
-];
+import { SERVICE_PATH } from "@/constants/servicePath";
+import useFindFolderAndHistory from "@/hooks/useFindFolderAndHistory";
 
 const FolderTree = () => {
   const pathname = usePathname();
-  console.log(pathname);
+  const matched = SERVICE_PATH.find((p) => pathname.includes(p.path));
+  const service = matched ? matched.service : undefined;
 
-  // const {data} = useQuery({
-  //   queryKey: ["sidebar-history", pathname],
-  //   queryFn: () =>
-  // })
+  const { folderInfiniteQuery, historyInfiniteQuery } =
+    useFindFolderAndHistory(service);
+
+  console.log(folderInfiniteQuery.data);
+  console.log(historyInfiniteQuery.data);
 
   return (
     <ul className="space-y-1 text-sm">
-      {dummy.map((n) => (
-        <TreeNode key={n.id} node={n} />
+      {(historyInfiniteQuery.data ?? []).map((h) => (
+        <TreeNode key={h.id} node={{ id: h.id, name: h.name }} />
       ))}
     </ul>
   );

--- a/src/components/ui/sidebar/TreeNode.tsx
+++ b/src/components/ui/sidebar/TreeNode.tsx
@@ -1,3 +1,7 @@
+import { readLatestHistory } from "@/apis/history.api";
+import { SERVICE_PATH } from "@/constants/servicePath";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
 import React from "react";
 
 interface TreeNodeData {
@@ -12,11 +16,48 @@ interface TreeNodeProps {
 
 const TreeNode = ({ node }: TreeNodeProps) => {
   const hasChild = node.children && node.children?.length > 0;
+
+  const pathname = usePathname();
+  const matched = SERVICE_PATH.find((p) => pathname.includes(p.path));
+  const service = matched ? matched.service : undefined;
+
+  const { data, refetch } = useQuery({
+    queryKey: ["readLatestHistory", service, node.id],
+    queryFn: () =>
+      readLatestHistory({ service: service!, historyId: Number(node.id) }),
+    enabled: false,
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    retry: 1,
+  });
+
+  // 특정 항목 호버 시 미리 가져와서 체감 속도 향상
+  const queryClient = useQueryClient();
+  const handleHistoryMouseEnter = () => {
+    if (!service) return;
+    queryClient.prefetchQuery({
+      queryKey: ["readLatestHistory", service, node.id],
+      queryFn: () =>
+        readLatestHistory({ service: service!, historyId: Number(node.id) }),
+    });
+  };
+
+  const handleHistoryClick = async () => {
+    if (!service) return;
+    await refetch();
+  };
+
   return (
     <li>
       <div className="flex items-center gap-1">
-        <p>
-          {hasChild ? "📂" : "📄"} {node.name}
+        <p className="hover:cursor-pointer">
+          {hasChild ? "📂" : "📄"}{" "}
+          <span
+            onClick={handleHistoryClick}
+            onMouseEnter={handleHistoryMouseEnter}
+          >
+            {node.name}
+          </span>
         </p>
         {hasChild && (
           <p className="ml-[2px] text-[12px] text-[#565656]">

--- a/src/constants/servicePath.ts
+++ b/src/constants/servicePath.ts
@@ -1,0 +1,11 @@
+import { Service } from "@/types/common.type";
+
+export type ServicePath = {
+  path: string;
+} & Service;
+
+export const SERVICE_PATH: ServicePath[] = [
+  { path: "paraphrase", service: "paraphrase" },
+  { path: "summarize", service: "summary" },
+  { path: "citation", service: "cite" },
+];

--- a/src/hooks/useFindFolderAndHistory.ts
+++ b/src/hooks/useFindFolderAndHistory.ts
@@ -1,0 +1,63 @@
+import { findFolderList } from "@/apis/folder.api";
+import { findHistoryList } from "@/apis/history.api";
+import { useAuthStore } from "@/stores/auth.store";
+import { ServiceCode } from "@/types/common.type";
+import { Folder, FolderList } from "@/types/folder.type";
+import { History, HistoryList } from "@/types/history.type";
+import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
+
+const useFindFolderAndHistory = (service?: ServiceCode) => {
+  const planTier = useAuthStore((state) => state.planTier);
+
+  const folderInfiniteQuery = useInfiniteQuery<
+    FolderList,
+    Error,
+    Folder[],
+    [string, typeof service],
+    number
+  >({
+    queryKey: ["sidebar-folder", service],
+    queryFn: ({ pageParam }) =>
+      findFolderList({ service: service!, page: pageParam, size: 10 }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      const nextPage = lastPage.number + 1;
+      return nextPage < lastPage.totalPages ? nextPage : undefined;
+    },
+    enabled: !!service && planTier !== "Free",
+    staleTime: 60_000, // 데이터를 1분 동안은 신선한 것으로 간주
+    gcTime: 5 * 60_000, // 사용하지 않는 캐시를 5분 후 메모리에서 제거
+    retry: 1, // 실패 시 최대 1회 재시도
+    // 방법 1: 모든 페이지의 content를 합쳐 Folder[]로 변환
+    select: (data: InfiniteData<FolderList, number>) =>
+      data.pages.flatMap((p) => p.content),
+  });
+
+  const historyInfiniteQuery = useInfiniteQuery<
+    HistoryList,
+    Error,
+    History[],
+    [string, typeof service],
+    number
+  >({
+    queryKey: ["sidebar-history", service],
+    queryFn: ({ pageParam }) =>
+      findHistoryList({ service: service!, page: pageParam, size: 10 }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      const nextPage = lastPage.number + 1;
+      return nextPage < lastPage.totalPages ? nextPage : undefined;
+    },
+    enabled: !!service,
+    staleTime: 60_000, // 데이터를 1분 동안은 신선한 것으로 간주
+    gcTime: 5 * 60_000, // 사용하지 않는 캐시를 5분 후 메모리에서 제거
+    retry: 1, // 실패 시 최대 1회 재시도
+    // 방법 1: 모든 페이지의 content를 합쳐 History[]로 변환
+    select: (data: InfiniteData<HistoryList, number>) =>
+      data.pages.flatMap((p) => p.content.flatMap((w) => w.histories)),
+  });
+
+  return { folderInfiniteQuery, historyInfiniteQuery };
+};
+
+export default useFindFolderAndHistory;

--- a/src/types/auth.type.ts
+++ b/src/types/auth.type.ts
@@ -23,6 +23,7 @@ export type LoginResponseData = {
   id: string;
   email: string;
   role: string;
+  planId: number;
 };
 
 export type SignupResponseData = {

--- a/src/types/common.type.ts
+++ b/src/types/common.type.ts
@@ -6,3 +6,41 @@ export type SuccessResponseData = {
 export type Message = {
   message: string;
 };
+
+export type ServiceCode = "paraphrase" | "summary" | "cite";
+
+export type Service = {
+  service: ServiceCode;
+};
+
+// 공통 페이징 정렬 정보 타입
+export type SortInfo = {
+  empty: boolean;
+  sorted: boolean;
+  unsorted: boolean;
+};
+
+// 공통 페이징 정보 타입
+export type Pageable = {
+  pageNumber: number;
+  pageSize: number;
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+  sort: SortInfo;
+};
+
+// 공통 API 응답 구조
+export type ApiResponse<T> = {
+  content: T[];
+  pageable: Pageable;
+  totalPages: number;
+  totalElements: number;
+  last: boolean;
+  size: number;
+  number: number;
+  sort: SortInfo;
+  numberOfElements: number;
+  first: boolean;
+  empty: boolean;
+};

--- a/src/types/folder.type.ts
+++ b/src/types/folder.type.ts
@@ -1,0 +1,16 @@
+import { ApiResponse } from "./common.type";
+
+export type PageAndSize = {
+  page?: number;
+  size?: number;
+};
+
+export type FolderId = { folderId?: number };
+
+export type Folder = {
+  id: number;
+  name: string;
+  createdAt: string;
+};
+
+export type FolderList = ApiResponse<Folder>;

--- a/src/types/history.type.ts
+++ b/src/types/history.type.ts
@@ -1,0 +1,25 @@
+import { ApiResponse } from "./common.type";
+import { FolderId, PageAndSize } from "./folder.type";
+
+export type HistoryId = { historyId?: number };
+
+export type HistoryAndFolderId = HistoryId & FolderId;
+
+export type FolderIdWithPageAndSize = FolderId & PageAndSize;
+
+export type LatestHistory = {
+  id: number;
+  content: string;
+  lastUpdate: string;
+  citeId: number;
+};
+
+export type History = {
+  id: number;
+  name: string;
+  lastUpdate: string;
+};
+
+export type HistoryWrapper = { histories: History[] };
+
+export type HistoryList = ApiResponse<HistoryWrapper>;


### PR DESCRIPTION
## ✨ 주요 작업 내용

### **1. 폴더/히스토리 목록 조회**

- API 연동 및 무한 스크롤 적용
- 새로고침 없이도 최신 히스토리 반영

### **2. 히스토리 클릭 시 내용 조회**

- 응답만 받고 있으며, UI 반영은 추후 작업 예정

### 3. 요금제별 아이콘 표시

- 로그인 시 사용자의 플랜에 따라 다른 아이콘 노출

## 📢 안내 사항

- 히스토리/폴더 관련 기능은 아직 구현 중이라 일부 동작이 불완전할 수 있습니다.

## 👀 리뷰 요청 사항

- 이번 변경은 UI 변화가 거의 없어서 별도의 리뷰 포인트는 없습니다.

## 🚀 다음 작업

- **인용문 복사 기능**: 인용문 우측 복사 아이콘 클릭 시 클립보드 복사
- **인용문 변환 기능 논의**: 백엔드 파서 범위가 커 회의 후 진행 여부 결정
- **히스토리 상세 뷰 바인딩**: 우선 “변환 결과”만 표시 → 이후 사전 입력 내용까지 저장/표시
- **히스토리/폴더 이름 변경**: 변경 즉시 목록 반영
- **히스토리 폴더 이동**: 이동 즉시 목록 반영
- **히스토리/폴더 삭제**: 확인 모달 → 삭제 → 즉시 반영